### PR TITLE
[Devops] [Docker] [WIP] Docker course

### DIFF
--- a/devops/docker/bind-mounts.md
+++ b/devops/docker/bind-mounts.md
@@ -1,0 +1,15 @@
+## Bind mounts
+
+A sharing (mounting) a host directory/file into a container that just looks like a local file path - container is unaware this is coming from a host. Essentially, a bind mount is just a mapping of a host file or directory to a container file or directory. Unlike volumes which are completely managed by Docker, bind mounts are dependent on the directory structure of the host machine. This means that host files overwrite any files in the container. When we use a bind mount, a file or directory on the host machine is mounted into a container.
+
+Since bind mounts are host-specific, they cannot be part of a Dockerfile and have to be used at run-time with `docker container run`:
+
+Similarly to volumes, a bind mount is done with the `-v` flag but we pass in a full path instead of a name.
+
+```bash
+❯ docker container run -v /Users/enki/local_path:/path/container mysql
+```
+
+TEXT TO USE TO EXTRACT QUESTION:
+
+> Bind mounts have limited functionality compared to volumes. When you use a bind mount, a file or directory on the host machine is mounted into a container. The file or directory is referenced by its full or relative path on the host machine. By contrast, when you use a volume, a new directory is created within Docker’s storage directory on the host machine, and Docker manages that directory’s contents.

--- a/devops/docker/container-philosophy.md
+++ b/devops/docker/container-philosophy.md
@@ -1,0 +1,9 @@
+## Container Philosophy
+
+Containers are meant to be **immutable** and **ephemeral**.
+This allows us to build an immutable infrastructure where we only start/stop and re-deploy containers but never change them.
+Any update is done by re-deploying a new container, not by changing existing ones.
+
+Containers derived from the same image are identical to each other in terms of their application code and runtime dependencies
+
+But unlike images, which are read-only, running containers include a writable layer (the container layer) on top of the read-only layers of the image. Runtime changes, including any writes and updates to data and files, are saved in the container layer. Thus, multiple concurrent running containers that share the same underlying image may have container layers that differ substantially.

--- a/devops/docker/containers.md
+++ b/devops/docker/containers.md
@@ -2,8 +2,9 @@
 
 Read more link: https://www.docker.com/what-container
 
-Containers are the fundamental building blocks of the Docker toolkit.
-They effectively represent runtime instances of Docker images (more on Docker images later).
+Containers are a way of isolating an application with its own environment. It's alightweight alternative to full-blown virtualization.
+
+They are the fundamental building blocks of the Docker toolkit and effectively represent runtime instances of Docker images (more on Docker images later).
 
 A container can be viewed as an independent software environment that includes everything it needs to execute. We can use containers to isolate applications from each other and from the underlying infrastructure they are built on.
 

--- a/devops/docker/containers.md
+++ b/devops/docker/containers.md
@@ -1,0 +1,54 @@
+## Containers
+
+Read more link: https://www.docker.com/what-container
+
+Containers are the fundamental building blocks of the Docker toolkit.
+They effectively represent runtime instances of Docker images (more on Docker images later).
+
+A container can be viewed as an independent software environment that includes everything it needs to execute. We can use containers to isolate applications from each other and from the underlying infrastructure they are built on.
+
+In some sense, we can think of a Docker container as a light-weight virtual machine. But unlike a VM which creates a whole virtual operating system each time it runs, Docker's containerization architecture allows it to share a lot of the host's operating system resources across containers.
+
+A virtual machine is more isolated from the host but much heavier because it requires more resources. Docker is less isolated but the containers require significantly less resources, allowing us to easily run thousands of them on a single host. This approach provides a non-trivial performance boost and reduces the size of the application.
+
+A container can be created through the Docker CLI using the `docker container create` command:
+
+```bash
+# create a container from an `nginx` image
+❯ docker container create nginx
+
+# create a container from an `nginx` image, and
+# give it the name `webserver`
+❯ docker container create--name webserver nginx
+```
+
+To start or stop the container, we can do the following:
+
+```bash
+# start the webserver container
+❯ docker container start webserver
+
+# stop the webserver container
+❯ docker container stop webserver
+```
+
+In fact, creating and starting containers happens so frequently in Docker that we have a command just for that called `docker run`.
+
+In essence: `docker run = docker container create + docker container start`
+
+```bash
+# create and start a container
+# give it the name `webserver`,
+# expose port 80 from within the container to port 8080 on the host,
+# run it interactively in the shell
+# and instantiate it from an `nginx` image,
+❯ docker run --name webserver -p 8080:80 -it nginx
+```
+
+PQ: Docker container is more ??? than a VM which allows it to be started, stopped and replicated more ???
+Answers: light-weight, efficiently, isolated, frequently
+Correct: light-weight, efficiently
+
+RQ: To create and start a container in a single command, we use ???:
+Answers: `docker run`, `docker go`, `docker container create+start`, `docker begin`
+Correct: `docker run`

--- a/devops/docker/docker-cli.md
+++ b/devops/docker/docker-cli.md
@@ -1,0 +1,61 @@
+## Docker CLI
+
+Docker comes with a command-line interface (CLI) that uses the Docker REST API to control or interact with the Docker daemon. This gives us a fine-grain control to manipulate containers, images, networks, services and other Docker Objects.
+
+Most Docker CLI commands have 3 parts.
+
+They start with `docker`, followed by a subcommand which is usually a name of a Docker Object such as `image`, then followed by a command.
+
+For example, to list all containers, we can do:
+
+```bash
+❯ docker container ls
+```
+
+Likewise, to remove the `nginx` image, we can do:
+
+```bash
+❯ docker image rm nginx
+```
+
+In fact, `docker` has many commands that are generic across Docker Objects (containers, images, etc.) and can be applied to any of them.
+
+```bash
+# list all objects
+❯ docker OBJECT ls
+
+# remove object
+❯ docker OBJECT rm ID_OR_NAME
+
+# inspect an object (return a JSON metadata describing it)
+❯ docker OBJECT inspect
+
+# remove unused objects
+❯ docker OBJECT prune
+```
+
+To list available commands and other helpful information for `docker` itself or any of it's sub commands like `docker container`, we can suffix the command we want to examine with `--help`.
+
+```
+❯ docker attach --help
+Usage:  docker attach [OPTIONS] CONTAINER
+
+Attach local standard input, output, and error streams to a running container
+
+Options:
+      --detach-keys string   Override the key sequence for detaching a container
+      --help                 Print usage
+      --no-stdin             Do not attach STDIN
+      --sig-proxy            Proxy all received signals to the process (default true)
+```
+
+Docker CLI (and Docker in general) has a concept of "_batteries included but removable_".
+
+This essentially means that the default configurations in Docker are setup to be easy to use and solve the most common problems but that we can change most of the options under the hood. Defaults work well in many cases, but it's easy to overwrite them when needed.
+
+Q: To inspect a Docker `nginx` image, we'd run the command:
+Answers: `docker image inspect nginx`, `docker inspect image nginx`, `docker image nginx inspect`, `docker inspect nginx image`
+
+PQ: To fetch the logs for a Docker container named `webserver`, we'd run:
+Answers: `docker container logs webserver`, `docker logs container webserver`, `docker show logs webserver`, `docker container-logs`
+Correct: `docker container logs webserver`

--- a/devops/docker/docker-dns.md
+++ b/devops/docker/docker-dns.md
@@ -1,0 +1,117 @@
+### Docker Network DNS
+
+We can't really rely on IP addresses in a dynamic system like Docker.
+Using static IPs for talking to containers is an anti-pattern and should be avoided.
+Containers can fail or move and IP addresses can easily become invalid.
+
+This is why Docker DNS exists. Docker DNS uses container names as the equivalent
+of a host name for container communication.
+
+Any non-bridge network has automatic DNS resolution for all the containers on that virtual network using container names. Two containers can find each other on the same network no matter what their ip is.
+
+_Note_: The default `brigde` network doesn't come with this DNS behavior of container names.
+That's why it's **always** good practice to create your own networks.
+
+```bash
+# create network for a webapp
+❯ docker network create my_web_app
+
+# create container for one nginx server on our network
+❯ docker run --name webserver1 --detach --network my_web_app nginx:alpine
+
+# create container for another nginx server
+❯ docker run --name webserver2 --detach --network my_web_app nginx:alpine
+
+# ping second container from the first
+# doing the opposite would work as well
+❯ docker container exec -it webserver1 ping webserver2
+```
+
+```
+❯ docker container exec -it webserver1 ping webserver2
+PING webserver2 (172.20.0.3): 56 data bytes
+64 bytes from 172.20.0.3: seq=0 ttl=64 time=0.093 ms
+64 bytes from 172.20.0.3: seq=1 ttl=64 time=0.117 ms
+64 bytes from 172.20.0.3: seq=2 ttl=64 time=0.091 ms
+64 bytes from 172.20.0.3: seq=3 ttl=64 time=0.285 ms
+64 bytes from 172.20.0.3: seq=4 ttl=64 time=0.091 ms
+```
+
+Docker containers can have DNS aliases which behave pretty similar to actual DNS aliases.
+
+We can use the command `--network-alias` to create a network-scoped alias for a container.
+
+DNS Round Robbin Docker example using aliases.
+
+_Note_: [DNS Round Robin](https://en.wikipedia.org/wiki/Round-robin_DNS) basically means that we can have different hosts (ip addresses) with DNS aliases that respond to the same DNS name and then particular hosts are selected in a Round Robin fashion (for example, each host can get a specific time slice as the main ip behind the DNS name)
+
+For Docker particularly, this is useful in production to get around the fact that container names are unique. For example, this allows us to install the same app twice (maybe `dev` and `test`) on the same docker server and we need to, in both of those, call something `search` in the DNS.
+
+We can use do an `nslookup` within our container to see a list of aliased containers for a particular DNS name.
+
+```bash
+# create a new virtual network (default bridge driver)
+❯ docker network create dude
+
+# create two containers from elasticsearch:2 image
+# connected them to the `dude` network
+# and give each container an alias `search`
+❯ docker run -d --network dude --network-alias=search elasticsearch:2
+❯ docker run -d --network dude --network-alias=search elasticsearch:2
+
+# perform DNS lookup on the containers to see the aliases
+
+# from alpine
+❯ docker container run --rm --network dude alpine nslookup search
+
+# from centos
+❯ docker container run --rm --network dude centos curl -s search:9200
+```
+
+```
+❯ docker container run --rm --network dude alpine nslookup search
+nslookup: can't resolve '(null)': Name does not resolve
+
+Name:      search
+Address 1: 172.18.0.2 search.dude
+Address 2: 172.18.0.3 search.dude
+```
+
+Since DNS Round Robin isn't a proper Load Balancer, we might need to run the next command a few times until we see both containers:
+
+```
+❯ docker container run --rm --network dude centos curl -s search:9200
+{
+  "name" : "Morning Star",
+  "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "sf2Ph9qfTi-MwpnSiXU-1Q",
+  "version" : {
+    "number" : "2.4.6",
+    "build_hash" : "5376dca9f70f3abef96a77f4bb22720ace8240fd",
+    "build_timestamp" : "2017-07-18T12:17:44Z",
+    "build_snapshot" : false,
+    "lucene_version" : "5.5.4"
+  },
+  "tagline" : "You Know, for Search"
+}
+
+❯ docker container run --rm --network dude centos curl -s search:9200
+{
+  "name" : "Stephen Strange",
+  "cluster_name" : "elasticsearch",
+  "cluster_uuid" : "iBT3fP6-TSe08WEoa5SIsA",
+  "version" : {
+    "number" : "2.4.6",
+    "build_hash" : "5376dca9f70f3abef96a77f4bb22720ace8240fd",
+    "build_timestamp" : "2017-07-18T12:17:44Z",
+    "build_snapshot" : false,
+    "lucene_version" : "5.5.4"
+  },
+  "tagline" : "You Know, for Search"
+}
+```
+
+Summary
+
+* Containers shouldn't rely on IP's for inter-communication and should use container names instead.
+* DNS for friendly names is built-in if you use custom networks

--- a/devops/docker/docker-platform.md
+++ b/devops/docker/docker-platform.md
@@ -1,0 +1,21 @@
+## Docker Platform
+
+Docker uses a client-server architecture consisting of 2 parts.
+
+1. The Docker daemon (`dockerd`) which listens for requests through the Docker REST API and manages Docker objects such as containers, images, networks, and volumes.
+
+2. The Docker client (`docker`) which is front-facing CLI tool that users primarily interact with. It sends all commands to `dockerd` via the Docker REST API to do the heavy-lifting.
+
+The main parts of Docker that we interact with on a daily basis are Docker Objects such as images, containers, networks, volumes, plugins, etc.
+
+The Docker platform also has public registries (Docker Hub and Docker Cloud) that anyone can use to store and share Docker images.
+
+Any Docker container can run on any server that has the Docker daemon installed, regardless of the underlying operating system.
+
+PQ: What do the Docker daemon and Docker CLI use to communicate?
+Answers: Docker REST API, Docker SOAP API, Docker channels, Docker Objects
+Correct: Docker REST API
+
+RQ: The two main parts of the Docker architecture are the ??? and the ???
+Answers: Docker CLI, Docker daemon, Docker Object, Docker container
+Correct: Docker CLI, Docker daemon

--- a/devops/docker/dockerfile.md
+++ b/devops/docker/dockerfile.md
@@ -1,0 +1,64 @@
+## Dockerfile
+
+A Dockerfile represents an image creation spec.
+
+Essentially, it is just a text file with Docker-specific syntax that contains all the instructions the Docker daemon can use to build a specific image.
+
+Instructions in a Dockerfile are executed in order, top-down.
+
+The format of a Dockerfile is the following:
+
+```Dockerfile
+# Comment
+INSTRUCTION arguments
+```
+
+Dockerfile instructions are UPPERCASE by convention to more easily distinguish them from their arguments.
+
+Here's an example of a Dockerfile:
+
+```Dockerfile
+# Use the node image as the base image
+FROM node
+
+# Env variables
+ENV DOCKER_LEARNING="fun"
+
+# the RUN command allows us to run any shell command or bash script
+# available at this step of building the image.
+# This will have access to all environment variables created above it.
+RUN echo "Hello from the Enki image"
+
+# Expose port 1234 on the container (we still have to use -p to link this port to an exposed port on the host)
+EXPOSE 1234
+
+# CMD is a required command (and/or ENTRYPOINT)
+# It is a final command that will be run every time a container is launched (or restarted).
+# Only one CMD is allowed. If there are multiple, last one wins.
+CMD ["echo", "learning", "Docker", "is", "fun"]
+```
+
+A Dockerfile must start with a `FROM` instruction which initializes a new build stage and sets the base image for subsequent instructions.
+
+`FROM` may only be preceded by one or more `ARG` instructions, which represent externally passed build arguments.
+
+A Dockerfile must contain at least the `CMD` or the `ENTRYPOINT` instruction to indicate the start command for an image.
+
+The `RUN` instruction executes the commands in a new layer on top of the current image. Each successive `RUN` instructions builds a new image layer on top of the previous.
+
+Each Dockerfile instruction result gets cached.
+
+When evaluating each instruction, Docker will look for an existing image in its cache that it can reuse, rather than creating a new (duplicate) image.
+
+Whenever we change a line in the Dockerfile, the cached result for every line after it is invalidated and has to be re-computed.
+
+Due to this, a good convention is to keep the things that change the least at the top of the Dockerfile and things that change the most at the bottom.
+
+PQ: A Dockerfile contains instructions the Docker daemon uses to build containers.
+Answers: T, F
+Correct: F
+
+RQ: The result of each Dockerfile instruction is cached and dependent on the cached result of the instruction before it.
+
+Answers: cached, cached, computed, computed.
+Correct: cached, cached.

--- a/devops/docker/image-registries.md
+++ b/devops/docker/image-registries.md
@@ -1,0 +1,29 @@
+## Image registries
+
+Docker platforms comes with an image registry called Docker Hub on which anybody can store public images.
+
+We can think of Docker Hub being to Docker images what Github is to code repositories.
+
+When creating an image, Docker is configured by default to look for images on Docker Hub.
+
+```bash
+# pull a docker image with the tag 8.9.1 from docker hub
+# if the tag is omitted, docker pulls the `latest` tag
+❯ docker pull node:8.91
+```
+
+Docker Hub represents a public repository for docker images. In many ways, we can compare docker images to git repositories and Docker Hub to Github.
+
+Image ID is based on the SHA of the docker hub image.
+
+When we run a container and change files within an image, a copy-on-write happens. That file is extracted from the image and stored in the container layer. Any layers that were unchanged are just reused. In this manner, the container contains all of its files and the files that differ from the image we used to create the container.
+
+We can see this happening when we `push` or `pull` a docker image:
+
+```bash
+❯ docker image push enki:example
+a82b6c66a6d4: Layer already exists
+1941ca4a7a84: Layer already exists
+a2ae92ffcd29: Layer already exists
+example: digest: sha256:9e81asffa499922aea9877fg6a652be11asd25lmin331322nybys size: 948
+```

--- a/devops/docker/image-tags.md
+++ b/devops/docker/image-tags.md
@@ -1,0 +1,18 @@
+### Image Tags
+
+A docker image tag is similar concept to git tags. It is really just a pointer to a specific image commit (id).
+Multiple tags can point to the same image commit (id).
+
+The default tag is called `"latest"`. It is important to know that that is just the default tag and it is up to the image owner to make sure the newest version gets assigned this tag.
+
+```bash
+# pull a docker image with the tag 8.9.1 from docker hub
+# if the tag is omitted, docker pulls the `latest` tag
+❯ docker pull node:8.91
+```
+
+Only official images are allowed on Dockerhub without a user attached to the repo name. For example, the `nginx` is the only official image for Nginx built by the Docker team and Nginx team. If we want to publish our own nginx image, we have to re-tag it with our username, i.e. `enki/nginx`, and then push.
+
+```bash
+❯ docker image tag nginx:latest enki/nginx:latest
+```

--- a/devops/docker/images.md
+++ b/devops/docker/images.md
@@ -1,0 +1,54 @@
+## Images
+
+A Docker image represents a blueprint for creating containers.
+
+It contains the specification for instantiating a container, including the environment in which the container will run, the application code it will need and other runtime settings such as environment variables and config files.
+
+A Docker image is immutable; it only contains read-only layers, meaning that once an image is created it is never modified.
+
+Images can be composed from each other to minimize data repetition. This also means that if we need to modify an image, the only way is to extend it and add our changes on top.
+
+To make them space-efficient, images are designed to be composed of layers of other images, allowing a minimal amount of data to be sent when transferring images over the network.
+
+Every image starts with a blank layers known as scratch. Any change that happens after creates a new image layer.
+
+It's important to note that image layers are cached and can be reused between various images, allowing for storage savings.
+
+This is indicated by the `"Layer already exists"` message in the console output when pushing or pulling the image from a registry:
+
+```bash
+❯ docker image pull enki:example
+a82b6c66a6d4: Layer already exists
+1941ca4a7a84: Layer already exists
+a2ae92ffcd29: Layer already exists
+example: digest: sha256:9e81asffa499922aea9877fg6a652be11asd25lmin331322nybys size: 948
+```
+
+We can use the `docker history IMAGE_ID` command to show the layers of changes made on an image and their sizes.
+
+```
+❯ docker history nginx
+IMAGE               CREATED             CREATED BY                                      SIZE                COMMENT
+3f8a4339aadd        2 days ago          /bin/sh -c #(nop)  CMD ["nginx" "-g" "daem...   0B
+<missing>           2 days ago          /bin/sh -c #(nop)  STOPSIGNAL [SIGTERM]         0B
+<missing>           2 days ago          /bin/sh -c #(nop)  EXPOSE 80/tcp                0B
+<missing>           2 days ago          /bin/sh -c ln -sf /dev/stdout /var/log/ngi...   22B
+<missing>           2 days ago          /bin/sh -c set -x  && apt-get update  && a...   53.2MB
+<missing>           2 days ago          /bin/sh -c #(nop)  ENV NJS_VERSION=1.13.8....   0B
+<missing>           2 days ago          /bin/sh -c #(nop)  ENV NGINX_VERSION=1.13....   0B
+<missing>           2 weeks ago         /bin/sh -c #(nop)  LABEL maintainer=NGINX ...   0B
+<missing>           2 weeks ago         /bin/sh -c #(nop)  CMD ["bash"]                 0B
+<missing>           2 weeks ago         /bin/sh -c #(nop) ADD file:f30a8b5b7cdc9ba...   55.3MB
+```
+
+An image that doesn't extend any other image is known as the base image.
+
+Images are built using a special configuration file (usually) named Dockerfile and the `docker build` command.
+
+PQ: Docker images are composed of ???
+Answers: layers, containers, pixels, fragments
+Correct: layers
+
+RQ: A Docker image can be modified.
+Answers: T, F
+Correct: F

--- a/devops/docker/networks.md
+++ b/devops/docker/networks.md
@@ -1,0 +1,33 @@
+## Networks
+
+When we start a container, in the background we are connecting to a particular docker network, which by default is the "bridge" network.
+
+Each docker network routes out through a NAT firewall, which is the Docker Daemon configuring the host IP address on its default interface, so that our containers can get out and get back from the Internet or other networks.
+
+Docker allows us to create virtual network, to which one or more containers can attach to.
+A container can be attached to any number of virtual networks, including being not connected to any. Each network is an encapsulated environment that can have controlled communication with other docker networks or the Internet.
+
+The default network in docker is called the `bridge` network.
+
+Docker also allows us to skip virtual networks and use the host IP directly (with the `--network host` command)
+
+This is a special network that skips the virtual networking of docker and attaches a container directly to the host interface. This sacrifices some security by eliminating the strict containerization boundaries but could gain some performance improvements in high throughput networks.
+
+We can also remove the network interface completely with `--network none`, which removes `eth0` and only leaves us with the localhost interface in our container.
+
+```bash
+# Displays detailed information on a network
+❯ docker network
+  connect     # Connect a container to a network
+  create      # Creates a new network with a name specified by the user
+  disconnect  # Disconnects a container from a network
+  inspect     # Displays detailed information on a network
+  ls          # Lists all the networks created by the user
+  prune       # Remove all unused networks
+  rm          # Deletes one or more networks
+```
+
+```bash
+# connects the `webserver` container to the `my_app` network
+❯ docker network connect my_app webserver
+```

--- a/devops/docker/volumes.md
+++ b/devops/docker/volumes.md
@@ -1,0 +1,58 @@
+## Volumes
+
+Although containers are immutable and their data gets removed when they do, it is still useful sometimes to persist data through a container(s) lifecycle.
+
+In an ideal case, our containers should not contain unique data mixed in with the application binaries and should just recreate their contents on each deployment. However, this can't always be done.
+
+Docker has 2 approaches to deal with persistent data:
+
+1. Volumes
+2. Bind-mounts
+
+Volumes represent a special location outside of a container's file system to store persistent data. This preserves the data through the container lifespan and allows us to attach it to whatever container we want (including multiple containers). As far as the container is concerned, that volume is just a local file path. This means that volumes require manual deletion and won't be removed by removing the container. Another consequence is that volumes do not increase the size of a container.
+
+Volumes can be created using the `VOLUME` command in the Dockerfile, or by using the command line flags for `docker run`. The flags we can use are `--mount` or `--volume` (`-v` for short). The recommended approach is to use the `--mount` which is more verbose than `-v` or `--volume`, but the order of the values is not relevant, and the meaning of values is easier to understand.
+
+```bash
+❯ docker run -v webserver-volume:/~/dev/webserver nginx
+#             ^^^^^^^^^^^^^^^^:^^^^^^^^^^^^^^^^
+#             volume on host  : volume on container
+```
+
+```bash
+❯ docker run --mount source=webserver-volume,target=/~/dev/webserver nginx
+```
+
+When creating a volume with `docker run`, if the volume at that path (or with that name) doesn't exist, docker will create one for use. If it does exists, docker will use the existing volume without creating a new one.
+
+We can also create volumes directly using the `create` cli command.
+
+```bash
+❯ docker volume create abc
+```
+
+If our container generates non-persistent state data, we can use the `tmpfs` mount to avoid storing the data anywhere permanently. This will also increase the container’s performance since it will not write into the container’s writable layer.
+
+Due to their temporary lifespan, `tmpfs` mounts cannot be shared among containers.
+
+We can specify usage of `--tmpfs` in the `docker run` command:
+
+```bash
+❯ docker run --tmpfs ~/dev/webserver nginx
+# or using the --mount flag
+❯ docker run --mount type=tmpfs,destination=~/dev/webserver nginx
+```
+
+Using `docker volume create` is the only way we could change the driver for a volume.
+
+Q: Volume data is still available when we remove the container.
+Ans: T, F
+Correct: T
+
+Q: Multiple containers can share the same volume.
+Answers: T, F
+Correct: T
+
+Q: Volumes increase the size of the container.
+Answers: T, F
+Correct: F

--- a/devops/docker/what-is-docker.md
+++ b/devops/docker/what-is-docker.md
@@ -1,0 +1,17 @@
+## What is Docker
+
+Docker is an open-source tool designed to make it easier to create, run and deploy applications by using containers.
+
+The core idea of Docker comes down to the following concept: “_develop once, run anywhere_”.
+
+Using Docker we can package our application with all of its dependencies into a single container. This containerized application can be tested and built on a developer's local machine, then easily deployed to any Docker-enabled server without the need to re-test or re-adjust the container to the server environment.
+
+Docker enables us to separate our applications from our infrastructure so we can deliver software quickly. Developers can focus on writing the application code without worrying a lot about the system that it will ultimately be running on.
+
+PQ: Docker allows us to easily run and deploy our applications using ???.
+Answers: containers, virtual machines, databases, networks
+Correct: containers
+
+RQ: Docker allows us to develop our application ??? and run it ???
+Answers: once, anywhere, quickly, always
+Correct: once, anywhere


### PR DESCRIPTION
## Lesson order

- What is Docker

- Docker Platform

- Docker CLI

- Containers

- Images

- Container Philosophy

- Dockerfile

- Image registries

- Image Tags

- Volumes

- Bind mounts

- Networks

- Docker DNS

## Useful resources:

- https://github.com/veggiemonk/awesome-docker

### Tricks:

https://gist.github.com/BretFisher/70c61f0e6099eb60fcc6bc4569f21da9

Chaotic notes about docker tricks:

#### Get container ip (from the config)

```bash
# docker uses Go templates
❯ docker container inspect --format '{{ .NetworkSettings.IPAddress }}' CONTAINER_NAME_OR_ID
```

#### Remove all stopped containers

```bash
❯ docker container prune
```

[Specific Docker Inspect](https://blog.vizuri.com/specific-docker-inspect)

> Here is an interesting tidbit having to do with docker inspect. The inspect function will return metadata associated with the object identifier that you include. That object identifier may be a container id, image id, name or other resource.
> 
> If you use a name as an argument instead of an image id or container id and you happen to have a container with the same name as an image, inspect might return the info for the one that you did not intend.
> 
> The way to be specific with your inspect request is to include the –type option which requires an argument of container, image, volume or network.
> The reason that you should include the type argument is demonstrated in the following example.
> The following will run a bash shell in an ubuntu container but will name it as python.
> 
> ```bash
> docker run -it --name=python ubuntu bash
> ```
> 
> The following is how you might ask for an inspect on what you think is a python image.
> 
> ```bash
> docker inspect python
> ```
> 
> You might get back the metadata for the running container called python or you might get it for the image named python if there was one.
> 
> To be specific and indicate as to the resource the following refers to the image called python
> 
> ```bash
> docker inspect --type=image python
> ```
> 
> This refers to the container called python.
> 
> ```bash
> docker inspect --type=container python
> ```
> 
> The importance of specificity is that it will alleviate the risk of getting back metadata of a different type than you expected which might impact an automation function such as a shell script. The side effects of getting back unexpected metadata might be that a script is unable to parse the response and cause an error.

#### ARG CAN START BEFORE FROM

ARG is the only instruction that may precede FROM in the Dockerfile. See [Understand how ARG and FROM interact](https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact).

#### Dockerfile

When using `FROM`, we inherit almost everything from the image we are `FROM`-ing (but not environment variables!)

`CMD` vs `ENTRYPOINT`

#### Shell vs Exec form

TODO

#### Network

Quoted from a tweet @lizTheDeveloper shared at some point, can't seem to find it now.

> When mapping ports in the HOST:CONTAINER format, you may experience erroneous results when using a container port lower than 60, because YAML will parse numbers in the format `xx:yy` as sexagesimal (base 60)

#### Running a container in the background

Quote from [article](http://kimh.github.io/blog/en/docker/gotchas-in-writing-dockerfile-en/#hack_to_run_container_in_the_background):

> Instead of running with `docker run -i -t` image your-command, using `-d` is recommended because you can run your container with just one command and you don’t need to detach terminal of container by hitting `Ctrl + P + Q`.
> 
> However, there is a problem with `-d` option. **Your container immediately stops unless the commands are not running on foreground**.
> Docker requires your command to keep running in the foreground. Otherwise, it thinks that your applications stops and shutdown the container.
> 
> The problem is that some application does not run in the foreground. How can we make it easier?

Solution:

Docker allows us to run a container both in [detached](https://docs.docker.com/engine/reference/run/#detached) `--d` mode and in [foreground](https://docs.docker.com/engine/reference/run/#foreground) mode (`-t`, `-i` or `-it`)

```bash
docker run -t -d image
```

The bash will wait in the background

### Docker Network security

* Create apps so that frontend/backend sit on the same network
* App inter-communication should never leave the host
* All external ports are closed by default and specific ports
  can be exposed explicitly with the `-p` flag

## Upcoming insights:

- Docker Compose
- Docker Swarm