### PR TITLE
Fix typos

### DIFF
--- a/java/fundamentals/default-methods/instance-methods-are-preferred-over-default-methods.md
+++ b/java/fundamentals/default-methods/instance-methods-are-preferred-over-default-methods.md
@@ -47,9 +47,9 @@ public class Carrot
   extends Vegetable 
   implements Food {
   public static void main(String... args) {
-    Carrot carrot = new Carrot;
+    Carrot carrot = new Carrot();
     System.out.println(carrot.describe());
   }
 }
 ```
-Both `Vegetable` and and `Food` contain an implementation of `describe()`. When `carrot.describe()` is called, it will print `"A vegetable"`. This is because `Food.describe()` is a `default` method, while `Vegetable.describe()` is an instance method.
+Both `Vegetable` and `Food` contain an implementation of `describe()`. When `carrot.describe()` is called, it will print `"A vegetable"`. This is because `Food.describe()` is a `default` method, while `Vegetable.describe()` is an instance method.

--- a/python/core/basic-file-manipulation/how-to-open-a-file-object.md
+++ b/python/core/basic-file-manipulation/how-to-open-a-file-object.md
@@ -23,14 +23,14 @@ links:
 Consider the following syntax:
 
 ```
-obj = open(f_name, [access_mode],
+obj = open(file_name, [access_mode],
                       [buffering])
 ```
 
 Here's the disambiguation of its arguments:
 - `file_name`: string value that contains the name of the file
 - `access_mode`: it determines the mode in which the file has to be opened: `read`, `write`, `append`
-- `buffering`: there are two important values `0` (means no buffering) or `1` (means line buffering[1] is performed). If the value is grater than `1` then that will be considered the buffer's size
+- `buffering`: there are two important values `0` (means no buffering) or `1` (means line buffering[1] is performed). If the value is greater than `1` then that will be considered the buffer's size
 
 The supported modes for opening a file are:
 


### PR DESCRIPTION
a) Disambiguation refers to "file_name" instead "f_name"
b) grater <- greater