### PR TITLE
Corrects typo in Networking and Security subtopic.

### DIFF
--- a/linux/networking-and-security/ssh-maintain/setting-up-password-free-authentication.md
+++ b/linux/networking-and-security/ssh-maintain/setting-up-password-free-authentication.md
@@ -79,7 +79,7 @@ $ ??? -t ???
 * `ssh`
 * `keygen`
 * `sshKeygen`
-* `generatre`
+* `generate`
 * `ssh-rsa`
 * `public`
 * `private`


### PR DESCRIPTION
Changed "generatre" to "generate". Not a game changer, but still.