### PR TITLE
Fix typo in one Python code example

### DIFF
--- a/python/functional-programming/functional-programming/what-is-functional-programming.md
+++ b/python/functional-programming/functional-programming/what-is-functional-programming.md
@@ -61,7 +61,7 @@ calc_square = square
 
 # Passing a function as an argument:
 def calculate(x, func):
-  return funct(x)
+  return func(x)
 
 result = calculate(2, calc_square)
 print(result)


### PR DESCRIPTION
I think that there is a typo in the variable name in one Python workout.