### PR TITLE
Patch broken games

### DIFF
--- a/comp-sci/data-structures-and-algorithms/intro-graphs/what-should-it-be-stored-in.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/what-should-it-be-stored-in.md
@@ -32,6 +32,7 @@ Conga line representation.
 %exp
 You can hop in the conga line anywhere you want without disturbing more than 2 people.
 %
+
 ---
 
 ```
@@ -43,6 +44,7 @@ A way to undo actions.
 %exp
 The stack's last in, first out principle makes this an easy job.
 %
+
 ---
 ```
 Printing documents in order of their arrival.
@@ -53,6 +55,7 @@ Printing documents in order of their arrival.
 %exp
 You want the first document sent to be printed first (first in, first out).
 %
+
 ---
 ```
 Books on a bookshelf.
@@ -63,6 +66,7 @@ Books on a bookshelf.
 %exp
 You would have to move the other books to insert/remove one. The bookshelf also has, most of the times, fixed size.
 %
+
 ---
 ```
 Chess board.
@@ -73,6 +77,7 @@ Chess board.
 %exp
 The chessboard is in itself a fixed `8*8` matrix (two-dimensional array).
 %
+
 ---
 ```
 Egg hunt clues.
@@ -84,6 +89,7 @@ Egg hunt clues.
 %exp
 Clues are linked to one another (the previous one gets you to the next). Adding an additional clue shouldn't mean having to move every other clue.
 %
+
 ---
 ```
 A train.
@@ -94,6 +100,7 @@ A train.
 %exp
 From each car, you'd only be able to get to the next and the previous one.
 %
+
 ---
 ```
 Store recursion calls.
@@ -104,6 +111,7 @@ Store recursion calls.
 %exp
 The recursion goes as deep as possible, then computes the latest added operation or function. As this principle ressemblances the last in, first out approach, a stack should be used.
 %
+
 ---
 ```
 Store the first n numbers in the Fibonacci
@@ -117,6 +125,7 @@ sequence.
 %exp
 As you know the index of the last Fibonacci number you have to compute, declaring an array makes sense.
 %
+
 ---
 ```
 Cars in a drive-through.

--- a/comp-sci/networking/tools/networking-quiz.md
+++ b/comp-sci/networking/tools/networking-quiz.md
@@ -145,6 +145,7 @@ OSI stands for:
 %exp
 The `OSI` (Open System Interconnect) model is a conceptual framework that breaks down network communication into seven layers.
 %
+
 ---
 ```
 Which of the following OSI model layers

--- a/git/essentials/remote-repository/git-erminology.md
+++ b/git/essentials/remote-repository/git-erminology.md
@@ -34,6 +34,7 @@ full history of the project.
 %exp
 Centralized Version Control refers to a single, complete copy of the repository on a server, while Local Version Control means saving all file versions on the same machine.
 %
+
 ---
 ```
 A single server keeps all the versions of
@@ -46,6 +47,7 @@ the latest version.
 %exp
 Users of Distributed Version Control can access the whole history of the project and and Local Version Control stores files locally.
 %
+
 ---
 ```
 The most widely used Distributed Version
@@ -58,6 +60,7 @@ Control System.
 %exp
 Google Trends places `git` as the VCS with the most searches, accounting for 70% look-ups for the top 5 most-searched VCSs.
 %
+
 ---
 ```
 The git folder containing the changes
@@ -70,6 +73,7 @@ history.
 %exp
 The official name for a folder containing the git-specific files is `repository`.
 %
+
 ---
 ```
 A tracked file, stored in the repository.
@@ -81,6 +85,7 @@ A tracked file, stored in the repository.
 %exp
 If a file is in the repository, it means that it has been `committed`.
 %
+
 ---
 ```
 A tracked file, ready to be committed.
@@ -92,6 +97,7 @@ A tracked file, ready to be committed.
 %exp
 In order for a file to be `committed`, it has to be watched by git (`tracked`) and the changes to the file to be acknowledged (`staged`).
 %
+
 ---
 ```
 A file that git knows it is there.
@@ -103,6 +109,7 @@ A file that git knows it is there.
 %exp
 A file for which git calculates content differences is called a `tracked` file.
 %
+
 ---
 ```
 A file git doesn't know anything about.
@@ -114,6 +121,7 @@ A file git doesn't know anything about.
 %exp
 A new file in the local repository which is yet to be watched by git is called an `untracked` file.
 %
+
 ---
 ```
 A pointer to a specific base commit.
@@ -125,6 +133,7 @@ A pointer to a specific base commit.
 %exp
 Branching is a moment in time (commit history) when the main tree is split into two.
 %
+
 ---
 ```
 A copy of the repository as a whole.

--- a/java/fundamentals/dummy-workout/guess-the-class.md
+++ b/java/fundamentals/dummy-workout/guess-the-class.md
@@ -38,6 +38,7 @@ x.equalsIgnoreCase('ABC'); //true
 %exp
 The only class in Java that supports both the `equals` and `equalsIgnoreCase` methods is `String`.
 %
+
 ---
 ```
 ???
@@ -56,6 +57,7 @@ Among the given answers, `Stack` is the only one which supports both `.push()`  
 `.pop()` - returns the last element in the stack
 
 %
+
 ---
 ```
 ???.out.print("Enki");
@@ -69,6 +71,7 @@ Among the given answers, `Stack` is the only one which supports both `.push()`  
 Calling `System.out`'s `print` method will output the given argument in the console.
 
 %
+
 ---
 ```
 ???
@@ -85,6 +88,7 @@ The `java.io.File` class provides both the `.canWrite()` and `.getAbsolutePath()
 
 `.getAbsolutePath()` - returns the absolute path of the denoted file
 %
+
 ---
 ```
 double x = 5;
@@ -100,6 +104,7 @@ Class `math` supports `.floor()` method.
 
 `.floor()` method returns an approximate value to the nearest bigger `int` number.
 %
+
 ---
 ```
 ???

--- a/javascript/browser-apis/dummy-workout/this-isn-t-a-game-level-1.md
+++ b/javascript/browser-apis/dummy-workout/this-isn-t-a-game-level-1.md
@@ -38,6 +38,7 @@ console.log(this);
 %exp
 In global execution context(outside any function), `this` refers to the **global object**. In **web browsers**, the **window** object is also the **global object**.
 %
+
 ---
 ```
 function f(){
@@ -51,6 +52,7 @@ f();
 %exp
 Since the following **code** is not in **strict mode**, and because the value of `this` is not set by the call, `this` will default to the **global object**, in this case **window**.
 %
+
 ---
 ```
 function f(){
@@ -65,6 +67,7 @@ f();
 %exp
 In **strict mode** if `this` was not defined by the execution context, it remains **undefined**.
 %
+
 ---
 ```
 var user = {
@@ -83,6 +86,7 @@ user.showName();
 %exp
 When a **function** is called as a method of an object, its `this` is set to the object that the **method** was called on.
 %
+
 ---
 ```
 var obj = {add: function(){
@@ -99,6 +103,7 @@ console.log(sum.add());
 %exp
 An intersting feature of **JavaScript**'s prototype inheritance is how `this`, since the function `add` was called as method the object `sum`, refers to `sum`.
 %
+
 ---
 ```
 function user(){

--- a/javascript/browser-apis/dummy-workout/urls-in-js.md
+++ b/javascript/browser-apis/dummy-workout/urls-in-js.md
@@ -35,6 +35,7 @@ console.log(window.location.protocol);
 %exp
 The `window.location.protocol` property returns the web protocol of the page.
 %
+
 ---
 ```
 // For https://www.enki.com/
@@ -46,6 +47,7 @@ console.log(window.location.host);
 %exp
 `window.location.host` property returns the name of the internet host (of the current page).
 %
+
 ---
 ```
 // https://enki.com/#contact
@@ -57,6 +59,7 @@ console.log(window.location.pathname);
 %exp
 This property returns the pathname of the current page.
 %
+
 ---
 ```
 // https://enki.com/#contact
@@ -70,6 +73,7 @@ The property returns the anchor part of the URL, including the hash (#) sign.
 
 The anchor part of a `URL` is a internal page reference, it usually appears at the end of the `URL` and it refers to a section within a web page.
 %
+
 ---
 ```
 // For https://enki.com/#contact

--- a/javascript/core/arrays/foo-features-and-fun-facts.md
+++ b/javascript/core/arrays/foo-features-and-fun-facts.md
@@ -46,6 +46,7 @@ foo();
 %exp
 This is true because we are comparing two of the same thing. When we refer to `foo` inside the function declaration for `foo`, we are referring to the variable to which the function has been assigned. The name of the function is irrelevant and makes no difference semantically. Therefore we are comparing two of the same variable to which the same function is assigned and the result is `True`.
 %
+
 ---
 ```
 function aaa() {
@@ -73,6 +74,7 @@ alert(typeof aaa());
 ```
 Which does not return the object as you would expect, and results in the type of the function being `undefined`, instead of `object` as you might expect.
 %
+
 ---
 ```
 Number("1") - 1 == 0;
@@ -83,6 +85,7 @@ Number("1") - 1 == 0;
 %exp
 This is true because we are casting a string to a number, and then taking away that exact number from it. The result is zero, and comparison reflects this.
 %
+
 ---
 ```
 (true + false) > 2 + true;
@@ -93,6 +96,7 @@ This is true because we are casting a string to a number, and then taking away t
 %exp
 Booleans can be operands to the `+` operator in JavaScript. JS evaluates this by casting the booleans to integers and then adding them. True converts to 1 and False converts to 0. Therefore, this becomes false, as the left hand side of the inequality is equivalent to `1 + 0 = 1` and the right hand side is `2 + 1 = 3` and therefore the whole becomes `1 > 3` which is false.
 %
+
 ---
 ```
 function bar() {
@@ -111,6 +115,7 @@ console.log(typeof bar());
 %exp
 Considering the placement of the return, it is easy to make the mistake of thinking the above will result in `undefined`, although this is not the case. The result is `function` because JavaScript is compiled by browsers instead of being a purely interpreted language. Function declarations are evaluated during compile time, and therefore while creating the `bar` function `foo` is also created, since it is in the scope of the `bar` function. If it were a function *expression* instead of a *declaration* `undefined` would be the result, since it would not have been evaluated at compile time.
 %
+
 ---
 ```
 "1" - - "1";
@@ -121,6 +126,7 @@ Considering the placement of the return, it is easy to make the mistake of think
 %exp
 This is an example of two strings being cast as numbers and then subtracted. The subtraction works as one would expect, and therefore a double subtraction is an addition and the result is 2.
 %
+
 ---
 ```
 [] + [] + 'foo'.split('');
@@ -131,6 +137,7 @@ This is an example of two strings being cast as numbers and then subtracted. The
 %exp
 Two arrays added together equal the empty string. This is because arrays are objects and **not** primitive data types. During evaluation JavaScript first tries to convert the array into a primitive, but this just results in the array, so it is converted to a string. Since the arrays are empty they both convert to the empty string, `""`, which when added to `"f,o,o"` produce the same, `"f,o,o"`.
 %
+
 ---
 ```
 new Array(5).toString();
@@ -141,6 +148,7 @@ new Array(5).toString();
 %exp
 This simply creates a new array with five empty items. The string representation of this is `",,,,"`.
 %
+
 ---
 ```
 var myArr = ['foo', 'bar', 'baz'];

--- a/javascript/core/dummy-workout/be-strict.md
+++ b/javascript/core/dummy-workout/be-strict.md
@@ -33,6 +33,7 @@ let x = 42;
 %exp
 The right syntax for strict mode in **JavaScript** is `use strict` not `useStrict`.
 %
+
 ---
 function foo() {
   "use strict";
@@ -43,6 +44,7 @@ foo();
 %exp
 `eval` doesn't have the same meaning in strict mode as it does normally.
 %
+
 ---
 (function foo() {
   "use strict";
@@ -54,6 +56,7 @@ foo();
 
 All attempts to do so will result in syntax errors.
 %
+
 ---
 (function foo() {
   "use strict";
@@ -64,6 +67,7 @@ All attempts to do so will result in syntax errors.
 %exp
 `let` is a keyword in **JavaScript**. It can’t be used to name a variable.
 %
+
 ---
 "use strict";
 function foo() {
@@ -75,6 +79,7 @@ foo();
 %exp
 `y` wasn't declared, so `y*4` can’t be evaluated.
 %
+
 ---
 "use strict";
 
@@ -92,6 +97,7 @@ foo.bar = 24;
 
 This means we can not change its value anywhere else in the program.
 %
+
 ---
 "use strict";
 with ({f: 24}) {
@@ -102,6 +108,7 @@ with ({f: 24}) {
 `with` rises some problems here because any variable name inside the block could map either to a property of the object passed as an argument, or to a variable in surrounding (or even global) scope.
 At runtime: it's impossible to know which beforehand.
 %
+
 ---
 "use strict";
 

--- a/javascript/core/dummy-workout/taming-the-beast.md
+++ b/javascript/core/dummy-workout/taming-the-beast.md
@@ -35,6 +35,7 @@ typeof(null);
 %exp
 `null` returns `object` when passed into `typeof` even though it is not technically an object. It is what is called a `primitive value` which is immutable. This is a "bug" in JavaScript that is not feasible to fix without breaking a lot of existing functionality in the language.
 %
+
 ---
 ```
 null instanceof Object
@@ -45,6 +46,7 @@ null instanceof Object
 %exp
 Although `null` looks like an `object` since `typeof(null)` returns `object`, `instanceof` returns `False` since `instanceof` checks for the presence of `constructor.prototype` in the given `object`'s prototype chain. i.e. `Object.getProtoypeOf(null) === Object.prototype`, which fails because it returns a `TypeError`. This is because null is not actually an object, this is a quirk of JavaScript.
 %
+
 ---
 ```
 var x = 0;
@@ -55,6 +57,8 @@ alert(x == false);
 * 0
 %exp
 This returns `True` as an alert. This is due to the `truthiness` values of integers in JavaScript. In JS, `0`, the integer, is always `falsy`, i.e. always evaluates to `False` when used or evaluated as a Boolean expression. When `truthiness` might cause logic issues remember to use *strict equal* and *strict not equal* `=== and !==` instead.
+%
+
 ---
 ```
 0.1 + 0.2 == 0.3
@@ -69,6 +73,7 @@ For this reason, rational numbers like `0.1` , whose denominator is not a power 
 
 The computer has to approximate the value to the closest one it can represent: for `0.1`, the closest approximation is `0.100000000000000005...` , that has 55 digits after the decimal point. The same happens with `2/10` . This is why the final result is not what we expected.
 %
+
 ---
 ```
 var enki;
@@ -80,6 +85,7 @@ enki == undefined;
 %exp
 The `var` keyword declares a variable, but in this case it is not initialized to a value. This means it is `undefined` so the result returned is `True`.
 %
+
 ---
 ```
 undefined = "Hello world"
@@ -92,6 +98,7 @@ enki == undefined;
 %exp
 Here, we've tried to override the the variable `undefined` to refer not to the primitive variable in global scope but to to a local variable, a string, containing `"Hello world"`. Therefore, when we try to compare `enki` and `undefined`, the result is different depending on the version of ECMAScript your JavaScript engine supports. ES5 and above silently prevents redefining built-in primitive types, but older engines such as ES3 do not. In this case we assume we are using ES6 syntax, so the redefinition is silently prevented and `enki` is `undefined`. Otherwise, on older engines it may be `False` since `"Hello world"` does not equal the undefined variable `enki`.
 %
+
 ---
 ```
 var x = 0;
@@ -103,6 +110,7 @@ alert(x === false);
 %exp
 This illustrates the importance of strict versus loose equality comparison. In this case we use strict comparison, so the result is `False`. This is because even though the truthiness of integer zero is `False`, strict equality comparison considers the types of the two operands first, and if they are different the two operands must both be different
 %
+
 ---
 ```
 (function(){
@@ -115,6 +123,7 @@ This illustrates the importance of strict versus loose equality comparison. In t
 %exp
 The returned answer is `object` since the `arguments` object is a local object inside all functions which, similar to an array, contains a collection of entries for all arguments passed into the function.
 %
+
 ---
 ```
 (function(x){
@@ -129,6 +138,7 @@ The returned answer is `object` since the `arguments` object is a local object i
 %exp
 Any property declared with `var` cannot be deleted from global scope or within a function using the `delete` keyword. Therefore the argument passed in, `Enki`, is retained and returned on execution.
 %
+
 ---
 ```
 var a = function b(){

--- a/javascript/core/numbers/infinity-game.md
+++ b/javascript/core/numbers/infinity-game.md
@@ -45,6 +45,7 @@ It is displayed when the upper limit of the floating numbers is exceeded.
 
 This limit is: 1.797693134862315E+308.
 %
+
 ---
 ```
 var x = Infinity - Infinity;
@@ -56,6 +57,7 @@ console.log(x); //prints ???
 %exp
 Infinity could be any number, so we can’t represent the result of `Infinity - Infinity` as a fixed value.
 %
+
 ---
 ```
 var x = -10/0;
@@ -67,6 +69,7 @@ console.log(x); //prints ???
 %exp
 There is also an option for a number to be infinitely small, which is represented by `-Infinity`.
 %
+
 ---
 ```
 var x = Infinity * 10;
@@ -78,6 +81,7 @@ console.log(x); //prints ???
 %exp
 Any fixed number multiplied by `Infinity` gives us infinity.
 %
+
 ---
 ```
 var x = 10/-0;

--- a/javascript/core/recipes-i/using-the-double-tilde-game.md
+++ b/javascript/core/recipes-i/using-the-double-tilde-game.md
@@ -40,6 +40,7 @@ console.log(~~x); //prints ???
 %exp
 The double tilde syntax is just shorthand for truncating numbers to integers. It is used as a shorthand for `Math.floor()` although it has a key difference in that it just removes any numbers after the decimal place. Therefore 3.5 becomes 3.
 %
+
 ---
 ```
 var x = -7.394;
@@ -51,6 +52,7 @@ console.log(~~x); //prints ???
 %exp
 Double tilde just removes any numbers after the decimal place, retaining any positive or negative.
 %
+
 ---
 ```
 var x = true;
@@ -62,6 +64,7 @@ console.log(~~x); //prints ???
 %exp
 Double tilde `true` evaluates to 1 since the double tilde is technically a *double NOT bitwise operator*. `True` evaluates to `1` and `False` evaluates to `0`.
 %
+
 ---
 ```
 var x = "Enki";
@@ -73,6 +76,7 @@ console.log(~~x); //prints ???
 %exp
 Double tilde never returns `NaN`, but if a check fails it simply returns `0`.
 %
+
 ---
 ```
 var x = "";
@@ -84,6 +88,7 @@ console.log(~~x); //prints ???
 %exp
 Double tilde never returns `NaN`, but if a check fails it simply returns `0`.
 %
+
 ---
 ```
 var x = false;

--- a/javascript/ecmascript-2015/dummy-workout/javascript-hard-mode.md
+++ b/javascript/ecmascript-2015/dummy-workout/javascript-hard-mode.md
@@ -47,6 +47,7 @@ Note that you need to assume **ECMAScript** 3rd edition. In addition, all `Error
 %exp
 The tricky part at this questions is that if there is a **parameter** with the same name as a local **variable**, then the local binding isn't **initialized** with `undefined`, but with the **value** of that parameter, `1` in this case.
 %
+
 ---
 ```
 (function() {
@@ -63,6 +64,7 @@ The tricky part at this questions is that if there is a **parameter** with the s
 %exp
 Arrow functions have lexical `this`, it **inherits** value from the context they are **defined** in. In this case both `this` calls are made within the context of `{x: outer}`. The fact that `.bind({x: 'inner'})` is applied on the first function doesn't change its **value**.
 %
+
 ---
 ```
 let x, { x: y = 1 } = { x }; y;
@@ -74,6 +76,7 @@ let x, { x: y = 1 } = { x }; y;
 %exp
 The first `let x` defines `x` with `undefined` value. `{x: y = 1} = {x}` is a **destructuring assingment**, it take **variable** `y` from **property** `x`. In the end, because `x` is `undefined` default value `1` is assigned to `y`.
 %
+
 ---
 ```
 (function() {
@@ -91,6 +94,7 @@ The first `let x` defines `x` with `undefined` value. `{x: y = 1} = {x}` is a **
 %exp
 In this situation as the **function** is executed with no explicit value of `this`. `let f` will be **assigned** `class h{ }`. `f`'s `typeof` is **function** and h as it is defined in the **expression position** has its `typeof` **undefined**.
 %
+
 ---
 ```
 (typeof (new (class { class () {} })))
@@ -111,6 +115,7 @@ new class{
 ```
 Now, the result of `typeof` on a default class is a simple `object`.
 %
+
 ---
 ```
 typeof (new (class F extends
@@ -128,6 +133,7 @@ The tricky part here is that the **grouping operator**  always returns the last 
 
 Now, we know that `Array`s don't have `.substring` method, so the result is `undefined`.
 %
+
 ---
 ```
 [...[...'...']].length

--- a/javascript/ecmascript-2015/master-es6-features/javascript-hard-mode-ii.md
+++ b/javascript/ecmascript-2015/master-es6-features/javascript-hard-mode-ii.md
@@ -52,6 +52,7 @@ g.next(); // {value: f, done: false}
 The mistake here is that only **generator** objects have `next()` method implemented. If we try to call `next()` as a chain, the second one will be applied to the **return value** of the first `next()` and not on the **generator** object.
 That is why `Error` is the right answer.
 %
+
 ---
 ```
 typeof (new class f()
@@ -64,6 +65,7 @@ typeof (new class f()
 %exp
 The above example results in **SyntaxError** because `class name f()` is not syntactically correct in JavaScript.
 %
+
 ---
 ```
 typeof `${{Object}}`.prototype
@@ -79,6 +81,7 @@ Here **ES6**'s short notation for **object literals** which states that `{Object
 
  In the end we use `prototype` property on the string '[Object Object]', this results in `undefined`.
 %
+
 ---
 ```
 ((...x, xs)=>x)(1,2,3)
@@ -90,6 +93,7 @@ Here **ES6**'s short notation for **object literals** which states that `{Object
 %exp
 Rest parameters can only appear on the last position. Here `...x` is used first, this results in `Error`.
 %
+
 ---
 ```
 let arr = [ ];
@@ -105,6 +109,7 @@ arr;
 %exp
 The variable `y` is in **scope**, but since it's never initialized it stays in **Temporal Dead Zone**, so it can't accessed.
 %
+
 ---
 ```
 (function() {

--- a/linux/system-and-package-management/system-monitoring-ii/gotta-know-them-all.md
+++ b/linux/system-and-package-management/system-monitoring-ii/gotta-know-them-all.md
@@ -40,6 +40,7 @@ authentication token?
 %exp
 `passwd`  is the utility used for updating authentication tokens. The password entered by the user is run through a key derivation function such that a hashed version of the new password is created and saved.
 %
+
 ---
 
 ```

--- a/web/html-and-css-basics/practical-css/c-s-splat.md
+++ b/web/html-and-css-basics/practical-css/c-s-splat.md
@@ -37,6 +37,7 @@ sub, sup {
 %exp
 Here we face a typo. `height` is misspelled.
 %
+
 ​---
 .list .opt:nth-child(m-1) {
 //.list .opt:nth-child(n-1) {
@@ -50,6 +51,7 @@ The `.nth-child` pseudo-selector can take as argument either a number, a keyword
 
 However, when stating a formula, the unknown variable must be `n`.
 %
+
 ​---
 .insight .link-name {
   position: absolute;
@@ -65,6 +67,7 @@ However, when stating a formula, the unknown variable must be `n`.
 %exp
 When using the `+` and `-` operators within the `calc` function keep in mind they must be padded by whitespaces.
 %
+
 ​---
 .insight-container < div {
 //  .insight-container > div {
@@ -78,6 +81,7 @@ When using the `+` and `-` operators within the `calc` function keep in mind the
 There is no `<` operator in CSS, but `>`.
 In our case, all `div` elements with a parent of class `insight-container` will be selected.
 %
+
 ​---
 .workout-end-container {
   letter-spacing: -4px;
@@ -91,6 +95,7 @@ To specify the font in CSS, one must use the `font-family` property.
 
 There is no such thing as `text-font`.
 %
+
 ​---
 .workout-feedback-container {
   color: #FF6F31;
@@ -102,6 +107,7 @@ There is no such thing as `text-font`.
 %exp
 Here we have another typo. Padding is correctly spelt with double `d`.
 %
+
 ​---
 .top-bar {
   position: fixed;
@@ -119,6 +125,7 @@ Here we have another typo. Padding is correctly spelt with double `d`.
 %exp
 The right syntax to specify the stack order of an element is `z-index: x`.
 %
+
 ​---​
 .navigationbar .location {
   font-family: "Roboto";
@@ -133,6 +140,7 @@ The right syntax to specify the stack order of an element is `z-index: x`.
 %exp
 `upper` doesn’t mean anything in CSS. However, `uppercase` can be used to transform all characters as intended.
 %
+
 ​---
 .insight .link-type-icon {
   color: #FFF;
@@ -148,6 +156,7 @@ The right syntax to specify the stack order of an element is `z-index: x`.
 %exp
 "width" in `min-widht` is misspelled here.
 %
+
 ​---
 .navigationbar .back {
   padding: 30px 50px 10px 15px;
@@ -162,6 +171,7 @@ The right syntax to specify the stack order of an element is `z-index: x`.
 %exp
 There is no `length` property in CSS. `width` should be used instead.
 %
+
 ​---
 .autoscroll-container {
   overflow: hidden;
@@ -174,6 +184,7 @@ There is no `length` property in CSS. `width` should be used instead.
 %exp
 There is a missing semicolon (`;`) near the `height` property. This will rise an error.
 %
+
 ​---
 .drop {
   color: #34495C;
@@ -189,6 +200,7 @@ There is a missing semicolon (`;`) near the `height` property. This will rise an
 %exp
 The correct name of the value for setting the current color is `currentColor`;
 %
+
 ---
 .field .input-field {
   color: #FFF;
@@ -204,6 +216,7 @@ The correct name of the value for setting the current color is `currentColor`;
 Using the `background` property with just one value argument will act as a shorthand for `background-color`.
 Hence, simply specifying a size instead of a color will raise an error.
 %
+
 ​---
 .insight-controls {
   line-height: 21px;
@@ -220,6 +233,7 @@ Hence, simply specifying a size instead of a color will raise an error.
 %exp
 CSS uses `:` for assigning values and not `=`.
 %
+
 ​---
 .password-field .eye {
   position: absolute;
@@ -236,6 +250,7 @@ CSS uses `:` for assigning values and not `=`.
 %exp
 The correct syntax for aligning text horizontally in CSS is `text-align` and not `align`.
 %
+
 ​---
 .share .share-view {
   background: #7F8C8D;
@@ -251,6 +266,7 @@ The correct syntax for aligning text horizontally in CSS is `text-align` and not
 %exp
 Overflow can be `hidden` but not `stack`.
 %
+
 ​---
 .share .share-view > h1 {
   text-transform: uppercase;
@@ -264,6 +280,7 @@ Overflow can be `hidden` but not `stack`.
 %exp
 CSS doesn't provide any `min-margin` property, but a `margin` one.
 %
+
 ​---
 .tabBar .tabBar-element {
   width: 25%;
@@ -281,6 +298,7 @@ CSS doesn't provide any `min-margin` property, but a `margin` one.
 The `font-size` property won't accept `12ms` as a correct value because it doesn't represent a size.
 Instead, `12px` wouldn't raise any errors.
 %
+
 ​---
 .segmented-control .label {
   width: 33%;
@@ -299,6 +317,7 @@ The `font-variant` can't take `uppercase` as value, but `small-caps`.
 
 The latter will also transform all letters of the text to uppercase, but will also decrease the their font size.
 %
+
 ---​
 .tabBar .tabBar-icon {
   display: block;


### PR DESCRIPTION
This PR solves a bug we had in our app:
Thematic breaks (`---`) which are required by the games to paginate the screens are not recorded properly by our parser. This can be bypassed by having a newline `\n` before the said breaks.

Games affected:
- Bugging Code
- What should it be stored in?
- Networking Quiz
- Giterminology
- Guess the Class
- This isn't a game
- URLs in JS
- Foo, features and fun facts
- Be strict
- Taming the beast
- Infinity
- Using the double tilde
- JavaScript Hard mode
- JavaScript Hard mode II
- Gotta know them all
- CSSplat