### PR TITLE
remove workout tag from first core section

### DIFF
--- a/javascript/core/arrays/arrays-can-be-used-as-stack.md
+++ b/javascript/core/arrays/arrays-can-be-used-as-stack.md
@@ -19,8 +19,6 @@ tags:
 
   - introduction
 
-  - workout
-
 
 links:
 

--- a/javascript/core/arrays/arrays.md
+++ b/javascript/core/arrays/arrays.md
@@ -22,11 +22,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Arrays

--- a/javascript/core/arrays/setting-the-length-of-an-array.md
+++ b/javascript/core/arrays/setting-the-length-of-an-array.md
@@ -19,12 +19,9 @@ standards:
 
 tags:
 
-  - workout
+  - introduction
 
   - obscura
-
-
-
 
 ---
 

--- a/javascript/core/arrays/splice.md
+++ b/javascript/core/arrays/splice.md
@@ -17,6 +17,9 @@ standards:
   js.data-types-structures.3: 1000
   js.standard-library.4: 1000
 
+tags:
+  - introduction
+
 links:
 
   - '[MDN](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Array/splice){website}'

--- a/javascript/core/flow-control/data-type-comparison-in-switch-statements.md
+++ b/javascript/core/flow-control/data-type-comparison-in-switch-statements.md
@@ -19,8 +19,6 @@ tags:
 
   - introduction
 
-  - workout
-
 
 links:
 
@@ -104,4 +102,3 @@ switch(x){
 * `nothing`
 * `'Hi!'`
 * `an error`
-

--- a/javascript/core/flow-control/if-statement.md
+++ b/javascript/core/flow-control/if-statement.md
@@ -19,11 +19,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # If Statement

--- a/javascript/core/flow-control/loops-part-1.md
+++ b/javascript/core/flow-control/loops-part-1.md
@@ -20,11 +20,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Loops - Part 1

--- a/javascript/core/flow-control/loops-part-2.md
+++ b/javascript/core/flow-control/loops-part-2.md
@@ -19,11 +19,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Loops - Part 2

--- a/javascript/core/functions-i/access-a-function-s-arguments-as-an-array.md
+++ b/javascript/core/functions-i/access-a-function-s-arguments-as-an-array.md
@@ -13,7 +13,6 @@ standards:
 
 tags:
   - introduction
-  - workout
 
 links:
   - '[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments){documentation}'
@@ -86,4 +85,3 @@ function myArray() {
 * args
 * sort
 * toArray
-

--- a/javascript/core/functions-i/declaring-functions.md
+++ b/javascript/core/functions-i/declaring-functions.md
@@ -21,11 +21,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Declaring Functions
@@ -48,11 +43,11 @@ add(1,2);//3
 
 **Return Values**
 
-In the above example we specified that we would return the function argument x plus argument y. 
+In the above example we specified that we would return the function argument x plus argument y.
 
 If we did not specify a return value in the above example then the function would return *undefined* e.g.
 
-``` 
+```
 function add(x, y){
 	x + y;
 }
@@ -98,4 +93,3 @@ console.log(add(2,3));
 * `5`
 * `false`
 * `error`
-

--- a/javascript/core/functions-i/function-arguments.md
+++ b/javascript/core/functions-i/function-arguments.md
@@ -19,10 +19,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
 
 ---
 
@@ -32,7 +28,7 @@ tags:
 ## Content
 
 When we pass primitive variables (such as numbers and strings) to functions in JavaScript they are *passed by value* which means that if we manipulate the argument value inside the function, changes will not be reflected outside the function.
- 
+
 However if we were to pass an object then changes *are* reflected on the object itself.
 
 For example:
@@ -83,4 +79,3 @@ console.log(per.name);
 * Alex
 * undefined
 * null
-

--- a/javascript/core/functions-i/function-constructor-vs-function-expression.md
+++ b/javascript/core/functions-i/function-constructor-vs-function-expression.md
@@ -27,9 +27,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
 links:
 
   - '[developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions#Function_constructor_vs._function_declaration_vs._function_expression){website}'
@@ -42,7 +39,7 @@ links:
 ---
 ## Content
 
-The concepts of constructors, declaration and expressions are often misused. Here is the official terminology according to MDN: 
+The concepts of constructors, declaration and expressions are often misused. Here is the official terminology according to MDN:
 
 Function defined with the `function` *constructor* assigned to the variable `multiply`:
 
@@ -105,4 +102,3 @@ var multiply = function(x, y) {
 * function expression of a `function` named `mult`
 * all
 * none
-

--- a/javascript/core/functions-i/functions-can-be-declared-after-use.md
+++ b/javascript/core/functions-i/functions-can-be-declared-after-use.md
@@ -21,11 +21,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Functions can be declared after use
@@ -33,21 +28,21 @@ tags:
 ---
 ## Content
 
-Function **declarations** load before other code is executed. This means that the function can be declared after it has been used. 
+Function **declarations** load before other code is executed. This means that the function can be declared after it has been used.
 
 For example:
 ```
 alert(foo()); // Alerts 'Enki'.
 // Function declaration
-function foo() { return 'Enki'; } 
+function foo() { return 'Enki'; }
 ```
 
 If however a function **expression** is used rather than a function **declaration** an error will be produced:
 
 ```
-alert(foo()); // Error! 
+alert(foo()); // Error!
 // Function expression
-var foo = function() { return 'Enki'; } 
+var foo = function() { return 'Enki'; }
 ```  
 This is because function **expressions** are evaluated from the top-down as normal.
 
@@ -57,8 +52,8 @@ This is because function **expressions** are evaluated from the top-down as norm
 Give the output:
 ```
 alert(foo()); // ???
-var foo = function() { return 'Enki'; } 
-``` 
+var foo = function() { return 'Enki'; }
+```
 
 * error
 * alerts 'Enki'
@@ -69,9 +64,8 @@ var foo = function() { return 'Enki'; }
 Give the output:
 ```
 alert(foo()); // ???
-function foo() { return 'Enki'; } 
-``` 
+function foo() { return 'Enki'; }
+```
 
 * alerts 'Enki'
 * error
-

--- a/javascript/core/intro-js/console-in-javascript.md
+++ b/javascript/core/intro-js/console-in-javascript.md
@@ -17,6 +17,9 @@ standards:
 
   js.standard-library.3: 10
 
+tags:
+  - introduction
+
 
 links:
 
@@ -54,7 +57,7 @@ console.trace()
 ```
 
 
-In JavaScript there is no specification for how `console.*` methods behave. Each environment adds its own methods and behaviour. 
+In JavaScript there is no specification for how `console.*` methods behave. Each environment adds its own methods and behaviour.
 
 When creating a web application, the use of `console.*` is critical for quickly debugging problems. Whenever you need more information on a variable, or would like to know where your code stops working, you should apply a console statement at the area in question. `console.*` statements can be viewed in Google Chrome by pressing `Ctrl+Shift+i`, and in Firefox by pressing `Ctrl+Shift+k`.
 
@@ -89,4 +92,3 @@ Log a message in the `console`:
 * `output`
 * `show`
 * `warn`
-

--- a/javascript/core/intro-js/javascript-history.md
+++ b/javascript/core/intro-js/javascript-history.md
@@ -15,8 +15,6 @@ tags:
 
   - introduction
 
-  - workout
-
   - obscura
 
 
@@ -63,4 +61,3 @@ The first version of JavaScript was developed by ??? in only 10 days.
 * Bjarne Stroustrup
 * James Gosling
 * Linus Torvalds
-

--- a/javascript/core/intro-js/javascript-or-ecmascript.md
+++ b/javascript/core/intro-js/javascript-or-ecmascript.md
@@ -12,7 +12,6 @@ inAlgoPool: false
 
 tags:
   - introduction
-  - workout
   - obscura
 
 links:

--- a/javascript/core/intro-js/using-javascript-on-a-web-page.md
+++ b/javascript/core/intro-js/using-javascript-on-a-web-page.md
@@ -13,6 +13,9 @@ inAlgoPool: false
 standards:
   js.javascript-syntax.2: 10
 
+tags:
+  - introduction
+
 ---
 # Using JavaScript on a web page
 

--- a/javascript/core/objects/deleting-properties.md
+++ b/javascript/core/objects/deleting-properties.md
@@ -17,6 +17,8 @@ standards:
   js.evaluate-expressions.6: 10
   js.evaluate-expressions.7: 10
 
+tags:
+  - introduction
 
 links:
 

--- a/javascript/core/objects/hasownproperty-method.md
+++ b/javascript/core/objects/hasownproperty-method.md
@@ -19,6 +19,9 @@ standards:
   js.evaluate-expressions.6: 10
   js.evaluate-expressions.7: 10
 
+tags:
+  - introduction
+
 
 links:
 

--- a/javascript/core/objects/keywords-in-hash-keys.md
+++ b/javascript/core/objects/keywords-in-hash-keys.md
@@ -14,6 +14,9 @@ standards:
   js.evaluate-expressions.6: 10
   js.evaluate-expressions.7: 10
 
+tags:
+  - introduction
+
 links:
   - '[bonsaiden.github.io](http://bonsaiden.github.io/JavaScript-Garden/){website}'
 

--- a/javascript/core/objects/object-part-1.md
+++ b/javascript/core/objects/object-part-1.md
@@ -23,8 +23,6 @@ tags:
 
   - introduction
 
-  - workout
-
 
 links:
 

--- a/javascript/core/objects/object-part-2.md
+++ b/javascript/core/objects/object-part-2.md
@@ -18,7 +18,6 @@ standards:
 
 tags:
   - introduction
-  - workout
 
 ---
 # Object - Part 2

--- a/javascript/core/syntax/double-and-single-quotes.md
+++ b/javascript/core/syntax/double-and-single-quotes.md
@@ -23,10 +23,6 @@ tags:
 
   - introduction
 
-  - json, readability
-
-
-
 
 ---
 
@@ -35,7 +31,7 @@ tags:
 ---
 ## Content
 
-Generally, double and single quotes are handled the same way. 
+Generally, double and single quotes are handled the same way.
 
 ```
 str1 = 'I\'m a string.';
@@ -65,4 +61,3 @@ JSON standard requires every string to be ??? quoted.
 
 * double
 * single
-

--- a/javascript/core/syntax/javascript-basics-part-1.md
+++ b/javascript/core/syntax/javascript-basics-part-1.md
@@ -16,7 +16,6 @@ standards:
 
 tags:
   - introduction
-  - workout
 
 ---
 # JavaScript Basics - Part 1

--- a/javascript/core/syntax/javascript-basics-part-2.md
+++ b/javascript/core/syntax/javascript-basics-part-2.md
@@ -15,7 +15,6 @@ standards:
 
 tags:
   - introduction
-  - workout
 
 ---
 # JavaScript Basics - Part 2

--- a/javascript/core/syntax/strict-mode.md
+++ b/javascript/core/syntax/strict-mode.md
@@ -92,4 +92,3 @@ How do you enable **strict mode** in EcmaScript 5?
 * `strict-mode`
 * `enable`
 * `on`
-

--- a/javascript/core/types-ii/the-difference-between-null-undefined-and-nan.md
+++ b/javascript/core/types-ii/the-difference-between-null-undefined-and-nan.md
@@ -21,11 +21,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # The difference between null, undefined and NaN
@@ -86,4 +81,3 @@ console.log(x);
 * `NaN`
 * `undefined`
 * `null`
-

--- a/javascript/core/types-ii/truthy-falsy-gotchas.md
+++ b/javascript/core/types-ii/truthy-falsy-gotchas.md
@@ -20,7 +20,6 @@ standards:
 
 tags:
   - introduction
-  - workout
 
 links:
   - '[Mozilla Developer Network](https://developer.mozilla.org/en/docs/Web/JavaScript/Equality_comparisons_and_sameness){website}'

--- a/javascript/core/types-ii/truthy-falsy.md
+++ b/javascript/core/types-ii/truthy-falsy.md
@@ -22,11 +22,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Truthy Falsy

--- a/javascript/core/types-ii/weak-vs-strict-equality-operator.md
+++ b/javascript/core/types-ii/weak-vs-strict-equality-operator.md
@@ -20,8 +20,6 @@ tags:
 
   - introduction
 
-  - workout
-
 
 links:
 

--- a/javascript/core/types/be-careful-when-using-typeof.md
+++ b/javascript/core/types/be-careful-when-using-typeof.md
@@ -17,8 +17,6 @@ tags:
 
   - introduction
 
-  - workout
-
 
 links:
 
@@ -32,7 +30,7 @@ links:
 ---
 ## Content
 
-`typeof` returns "object" for all objects, and nothing more specific. 
+`typeof` returns "object" for all objects, and nothing more specific.
 
 Examples:
 
@@ -67,4 +65,3 @@ typeof new Date();
 * null
 * var
 * Array()
-

--- a/javascript/core/types/types-boolean-and-number.md
+++ b/javascript/core/types/types-boolean-and-number.md
@@ -18,7 +18,6 @@ standards:
 
 tags:
   - introduction
-  - workout
 
 ---
 # Types - Boolean and Number

--- a/javascript/core/types/types-hoisting.md
+++ b/javascript/core/types/types-hoisting.md
@@ -15,9 +15,8 @@ standards:
   js.functions.5: 10
 
 tags:
-  - workout
+  - introduction
   - hoisting
-  - deep
   - variables
   - obscura
 

--- a/javascript/core/types/types-introduction.md
+++ b/javascript/core/types/types-introduction.md
@@ -15,7 +15,6 @@ standards:
 
 tags:
   - introduction
-  - workout
 
 ---
 # Types - Introduction

--- a/javascript/core/types/types-string.md
+++ b/javascript/core/types/types-string.md
@@ -21,11 +21,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Types - String
@@ -47,7 +42,7 @@ var longerText = "abc" +
 		"ghi";
 ```
 
-You can also use the backslash character to continue writing text on multiple lines (make sure nothing is after the backslash). 
+You can also use the backslash character to continue writing text on multiple lines (make sure nothing is after the backslash).
 
 ```
 var longerText = "abc\
@@ -99,4 +94,3 @@ var company = 'Enki';
 * first
 * second
 * none
-

--- a/javascript/core/types/types-undefined-and-null.md
+++ b/javascript/core/types/types-undefined-and-null.md
@@ -19,11 +19,6 @@ tags:
 
   - introduction
 
-  - workout
-
-
-
-
 ---
 
 # Types - Undefined and Null
@@ -84,4 +79,3 @@ undefined == null
 
 * true
 * false
-

--- a/javascript/npm/intro-npm/semantic-versioning.md
+++ b/javascript/npm/intro-npm/semantic-versioning.md
@@ -12,11 +12,13 @@ category: must-know
 parent: package-json
 
 standards:
-  js.npm-tasks-and-modules-manager.3: 10
+  js.npm-publish.3: 10
   js.use-open-source-javascript-packages.1: 10
 
 tags:
   - introduction
+  - workout
+  - deep
 
 ---
 # Semantic versioning


### PR DESCRIPTION
had a conversation with Kirill, I think if we remove the "workout" tag from the first section of Core, people who select `workouts` but not `introduction` will begin their placement test in the right place.