### PR TITLE
📚❗️Standards Definition: SQL 

### DIFF
--- a/sql/ddl/README.md
+++ b/sql/ddl/README.md
@@ -11,3 +11,58 @@ sections:
     - indices
     - storing-blobs
     - storing-json
+
+standards:
+  create-database:
+    name: Create a database
+    description: This standard covers the skill of creating a database.
+    objectives:
+      0: Create a database
+      1: Create database users
+      2: Provision roles for database users
+  define-tables:
+    name: Write statements to create tables
+    description: This standard covers the skill of creating tables.
+    objectives:
+      0: Create a new table
+      1: Set the data type or name of columns in a new table
+      2: Write statements to add a Trigger to a table
+      3: Write statements to add a Rule to a table
+      4: Write statements to add Primary or Foreign Keys to a new table
+  define-columns:
+    name: Write statements to create or modify columns
+    description: This standard covers operations specific to columns in tables in an RDBMS.
+    objectives:
+      0: Create columns in a table
+      1: Modify the name or data type of columns in a table
+      2: Modify other properties of a column in a table
+  define-relationships:
+    name: Write statements to create or modify relationships
+    description: This standard covers the definition of relationships between two tables in an RDBMS.
+    objectives:
+      0: Create a one-to-many relationship by creating a reference to a foreign key
+      1: Create a many-to-many relationship with two foreign key references
+      2: Create a one-to-one relationship by creating a reference to a foreign key and setting a constraint
+      3: Join a table to itself with self-referencing foreign keys
+  define-indices:
+    name: Write statements to create or modify indices
+    description: This standard deals with creation of indicies on a database table
+    objectives:
+      0: Create an index on a database table
+      1: Modify the properties of an index on a database table
+      2: Create a clustered index on a database table
+      3: Distinguish between effective indicies that improve the performance of table lookups and ineffective indicies that hinder performance
+  define-sequences-or-default-values:
+    name: Write statements to create or modify sequences or default values
+    description: This standard has to do with columns with computed values, sequences, auto-incrementing values, GUIDs, defaults, etc. Any type of data-altering computation that is defined by the column.
+    objectives:
+      0: Write column definitions to create auto-incrementing IDs
+      1: Write column definitions with default values that are static
+      2: Write column definitions with default values that are computed
+  choose-sql-datatype:
+    name: Choose the correct SQL datatype to store a type of data
+    description: This standard covers the skill of choosing a data type for a column of data in a table based on the desired behavior of the column.
+    objectives:
+      0: Distinguish and choose between numeric types based on the desired behavior of the column
+      1: Distinguish and choose between string types based on the desired behavior of the column
+      2: Distinguish and choose between large content types based on the desired behavior of the column

--- a/sql/ddl/README.md
+++ b/sql/ddl/README.md
@@ -66,3 +66,4 @@ standards:
       0: Distinguish and choose between numeric types based on the desired behavior of the column
       1: Distinguish and choose between string types based on the desired behavior of the column
       2: Distinguish and choose between large content types based on the desired behavior of the column
+      

--- a/sql/dql/README.md
+++ b/sql/dql/README.md
@@ -8,12 +8,63 @@ sections:
   '0':
     - what-is-sql
     - basic-selects
-    - basic-queries    
+    - basic-queries
     - write
   '1':
     - aggregate-queries
     - joins
     - database-clients
+
+standards:
+  connect-client:
+    name: Connect a database client to a database server
+    description: This standard deals with the skill of establishing a connection to a database server.
+    objectives:
+      0: Connect any database client to a database server on a local host
+      1: Connect any database client to a database server on a remote host
+      2: Break down connection URIs into their component elements (protocol, hostname, credentials, port, database name, etc)
+      3: Assemble connection URIs from component elements
+  read-single-table:
+    name: Write queries to read data from single tables
+    description: This standard specifically has to do with writing a query to read data from one table.
+    objectives:
+      0: Use the SELECT command to get data from a table
+      1: Use the WHERE clause to filter rows of data from a table
+      2: Filter the columns returned by a SELECT command
+      3: Use the ORDER BY command to sort a result set by the value of a column, or multiple columns
+  read-multiple-tables:
+    name: Write queries to read data from multiple related tables
+    description: This standard specifically deals with the skill of JOINing multiple tables together to produce a set of data. This means that the data model for this assessment needs to have at least one join table that relates two different tables together, and one that relates a table to itself. A good example model is relating Users to other Users (as in friendships), and Users to Items they've purchased through Orders (a join table).
+    objectives:
+      0: Use INNER, LEFT, RIGHT, OUTER, and JOIN to relate data across multiple tables
+      1: Write a query to relate two tables using a join table
+      2: Write a query to relate a table to itself using a join table
+  aggregate-single-table:
+    name: Write queries to aggregate data from a single table
+    description: This standard has to do with the skill of data aggregation from a single table. 1 or more columns of data, filtered or not, are reduced to a single value, from a single set.
+    objectives:
+      0: Use the COUNT, SUM, AVG functions to reduce a set to a single value
+      1: Use the MAX, MIN functions to search for the boundaries of set of data
+      2: Combine multiple columns' values in the aggregation of a set of data
+      3: Use GROUP BY to aggregate data in subsets of data
+  aggregate-multiple-tables:
+    name: Write queries to aggregate data from multiple related tables
+    description: This standard deals specifically with the aggregation of data across multiple joined sets of data.
+    objectives:
+      0: Aggregate data using the GROUP BY statement and the COUNT, SUM, and AVG to collate information across related tables
+      1: Use MAX and MIN to look at the boundaries of a subset of data that is distributed across multiple tables
+      2: Use columns from related tables to aggregate a compound value
+  write:
+    name: Write queries to insert, update or delete data in a single table
+    description: This standard deals specifically with writes to the database, using INSERT, UPDATE, or DELETE operations.
+    objectives:
+      0: Insert a single row of data using the INSERT command
+      1: Insert multiple rows of data using the INSERT command
+      2: Populate a table with the INSERT INTO command
+      3: Update 1 or more columns of data with the UPDATE command
+      4: Use a WHERE clause with the UPDATE command to conditionally update rows of data
+      5: Delete data with the DELETE command
+      6: Use a WHERE clause with the DELETE command to conditionally delete rows of data
 
 next:
   - sql:ddl


### PR DESCRIPTION
We can merge this as soon as backend changes are deployed.

Mentions:
 Looking at: https://github.com/sagelabs/standards/tree/master/sql, in DDL, there's a standard named in the linked README, but missing from the course folder, namely `Attach indices to lookup columns`

Todo:
- [ ] create a PR which retriggeres all references to these standards from insights/exercises