### PR TITLE
📚❗️Standards Definition: JavaScript

### DIFF
--- a/javascript/browser-apis/README.md
+++ b/javascript/browser-apis/README.md
@@ -12,6 +12,53 @@ sections:
     - toolbox-ii
     - user-interaction
 
+standards:
+  dom:
+    name: Use the Document object to programmatically create and alter layouts
+    description: This standard specifically deals with manipulating the Document Object Model
+    objectives:
+      0: Create and append elements to the Document
+      1: Create complex elements from structured data
+      2: Modify the style or state of elements
+      3: Create events handlers for events relating to Document elements
+  browser-apis-device:
+    name: Use modern Browser APIs to interact with the device
+    description: This standard deals with use of device sensors and details made available by the browser on the device.
+    objectives:
+      0: Use modern browser APIs to interact with device performance information, like battery level, memory usage, or storage availability
+      1: Use modern browser APIs to interact with device location information, like location or accelerometer data
+      2: Use modern browser APIs to interact with device ports, such as serial or usb
+  browser-apis-browser:
+    name: Use built-in Browser APIs to control the browser
+    description: This standard specifically deals with using built-in APIs to control aspects of modern browsers.
+    objectives:
+      0: Use the Geolocation API to determine a browser's physical location
+      1: Use browser APIs to manage windows and tabs
+  browser-store-data:
+    name: Use browser APIs to store and manage data on the client
+    description: This standard covers issuing instructions to cache assets or store data in any available API that persistently stores data on the client.
+    objectives:
+      0: Use localstorage to store data
+      1: Use WebSQL to store data
+      2: Use Cookies to store data
+      3: Use Session storage to store data
+      4: Direct the browser to cache responses
+      5: Direct the browser to clear data from persistent stores
+  browser-connect-to-remote-hosts:
+    name: Use built-in Browser APIs to connect to remote hosts
+    description: This standard deals specifically with using the browser to connect to remote hosts via any network protocol.
+    objectives:
+      0: Use the XMLHttpRequest API to send and receive data from a remote host
+      1: Use the WebSocket API to maintain a stateful connection between a browser and remote host
+      2: Use the WebRTC API to create a real-time communication channel between two browsers
+  browser-tooling:
+    name: Use modern browser tooling and APIs to improve load performance
+    description: This standard deals with use of Chrome Dev Tools, Safari Web Inspector, Firefox Developer Console, or Internet Explorer Developer Tools. Not all toolchains support all activities, so some performances may require the use of a specific toolset.
+    objectives:
+      0: Use in-browser tooling to measure resource loading times to identify network bottlenecks
+      1: Use in-browser tooling to profile memory issues and identify memory leaks
+      2: Use in-browser tooling to analyze runtime performance and improve efficiency
+
 next:
   - javascript:node
 

--- a/javascript/core/README.md
+++ b/javascript/core/README.md
@@ -30,5 +30,125 @@ sections:
     - async
     - async-tips
 
+standards:
+  javascript-syntax:
+    name: Identify JavaScript Syntax
+    description: This standard has to do with identifying and evaluating the results of JavaScript Syntax.
+    objectives:
+      0: Identify JavaScript control structures
+      1: Identify JavaScript statements
+      2: Evaluate the validity of JavaScript syntax
+  data-types-structures:
+    name: Identify and use JavaScript's data types and structures and their respective operations
+    description: This standard specifically relates to the operations performed on different data types.
+    objectives:
+      0: Identify primitive types in JavaScript
+      1: Use primitive operators to operate on primitive types
+      2: Identify data structures in JavaScript
+      3: Use built-in data structures in JavaScript
+      4: Perform primitive operations on data structures in JavaScript
+      5: Access deeply nested data structures
+      6: Functionally iterate over a data structure
+  write-expressions:
+    name: Write Javascript Expressions
+    description: This standard deals with the composition of expressions in JavaScript using any kind of data type, as well as the composition of complex expressions with multiple sub-expressions.
+    objectives:
+      0:  Write simple expressions in JavaScript using each data type
+      1: Compose simple expressions into complex expressions
+      2: Decompose complex expressions into simple expressions
+  evaluate-expressions:
+    name: Evaluate JavaScript Expressions
+    description: This standard covers reading JavaScript expressions and accurately predicting the result.
+    objectives:
+      0: Accurately predict the return value of simple numeric JavaScript expressions
+      1: Accurately predict the return value of complex numeric JavaScript expressions
+      2: Accurately predict the return value of simple string JavaScript expressions
+      3: Accurately predict the return value of complex string JavaScript expressions
+      4: Accurately predict the return value of simple boolean JavaScript expressions
+      5: Accurately predict the return value of complex boolean JavaScript expressions
+      6: Accurately predict the result of simple JavaScript expressions operating on a data structure
+      7: Accurately predict the result of complex JavaScript expressions operating on a data structure
+      8: Accurately predict the result of complex data structure access operations
+      9: Accurately predict the return value of function or constructor
+      10: Accurately predict the type of a given expression
+  control-flow:
+    name: Use control flow structures to control the flow of a program in JavaScript
+    description: |
+      This standard deals with any use of a control flow structure used to control the flow of a program in order to execute the correct statements in the correct logical sequence in JavaScript.
+
+      Creating and calling functions is contained within this standard only in the sense that it must be demonstrated that one can use a function to logically order statements or conditionally execute them. The functions can be created by any method, be declared anywhere, and can be called in any fashion. Creating methods on an object and using them, or calling the map function with an arrow function that the user defines work equally well for this purpose.
+
+      try..catch blocks is contained within this standard only in the sense that it deals with control flow from an exceptions perspective.
+    objectives:
+      0:  Make a decision about which control flow structure to use in order to execute statements in the correct logical sequence
+      1: Demonstrate the use of if statements
+      2: Demonstrate the use of switch statements
+      3: Demonstrate the use of for, for of, for in loops
+      4: Demonstrate the use of while loops
+      5: Demonstrate the use of creating and calling functions
+      6: Demonstrate the use of using a try..catch block to handle exceptions programmatically
+  functions:
+    name: Use functions in JavaScript
+    description: This standard covers the declaration of functions in JavaScript, proper use of variable scope, return values, and calling functions.
+    objectives:
+      0: Write a function
+      1: Write a parameterized function
+      2: Write a parameterized function with defaults
+      3: Write a named function
+      4: Write an anonymous function
+      5: Recognize the rules of variable scope with respect to functions
+      6: Use variable scope to effectively encapsulate code by function
+      7: Use variable scope to effectively constrain the memory use of a parameterized function
+      8: Distinguish between function expressions and named functions
+  standard-library:
+    name: Use the standard library to perform common operations on data with JavaScript
+    description: This standard covers common operations on data that are provided by the standard library of most JavaScript environments.
+    objectives:
+      0: Perform common string manipulation tasks
+      1: Perform math operations, use the Math built-in library
+      2: Accurately perform type-casting operations
+      3: Use Console methods to output data
+      4: Perform collection manipulation with Array methods (map, filter, reduce, etc)
+      5: Perform Date manipulation operations, use the Date built-in library
+  async:
+    name: Perform and manage asynchronous operations in JavaScript
+    description: This standard specifically deals with writing code to perform asynchronous operations. Any time code awaits some asynchronous event before being run. It does not deal with reasoning about asynchronous operations, except insofar as one must reason about the JavaScript-specific implementation details and considerations.
+    objectives:
+      0: Use callbacks to asynchronously execute code
+      1: Explain the event loop in JavaScript
+      2: Use Promises to perform sequential asynchronous operations
+      3: Use async and await to create asynchronously resolving generator functions
+  execution-context:
+    name: Use and manipulate the execution context of a function in JavaScript
+    description: This standard deals with the use of the call, apply, and bind methods, as well as manipulation of the this object, as well as knowledge of what the this value will be given a line in a snippet of code.
+    objectives:
+      0: Use bind to produce a bound function
+      1: Use call and apply to call a function with an explicit this value
+      2: Use this to store properties on an execution context
+      3: Use this to modify an instance's properties
+      4: Identify what the value of this is given a line in a code snippet
+  prototype-class:
+    name: Use prototypes to create class-like objects in JavaScript
+    description: This standard covers using the prototype of a constructor function to create a class-like object, from which instances can be produced that share common methods and properties, but not common property values.
+    objectives:
+      0: Use a constructor function and the execution context of that function to produce an instance with particular properties
+      1: Use the prototype of the constructor function to set methods on instances produced by the constructor function
+      2: Modify the instance using a prototype method
+  prototype-inherit:
+    name: Use prototypes to create class-like objects in JavaScript
+    description: This standard covers using the prototype of a constructor function to create a class-like object, and inheriting methods and properties from another object higher in the prototype chain, from which instances can be produced that share common methods and properties, but not common property values.
+    objectives:
+      0: Set the prototype of the constructor function to inherit methods on instances produced by the constructor function
+      1: Modify the instance using an inherited prototype's method
+  exceptions:
+    name: Identify and handle exceptions in JavaScript
+    description: This standard deals with exception handling in JavaScript, as well as the identification of different errors that JavaScript displays.
+    objectives:
+      0: Distinguish JavaScript error types
+      1: Identify the type of exception thrown from a JavaScript stack trace
+      2: Use a try..catch block to handle an exception
+      3: Create and throw a custom error type
+      4: Use the debugger statement with a JavaScript debugger
+
 next:
   - javascript:ecmascript-2015

--- a/javascript/ecmascript-2015/README.md
+++ b/javascript/ecmascript-2015/README.md
@@ -22,5 +22,95 @@ sections:
     - generators-proxy
     - master-es6-features
 
+standards:
+  new-declaration-keywords:
+    name: Use new variable declaration keywords to communicate more effectively with other developers
+    description: This standard deals with knowledge of the behavior of let and const and their proper use.
+    objectives:
+      0: Use let for block-scoped variables
+      1: Use const for variables that will not change
+  es6-extensions-standard-library:
+    name: Use extensions to JavaScript’s standard library to perform data analysis and manipulation
+    description: This standard covers improvements to existing data structures and other standard library utilities that were introduced in ECMAScript 2015.
+    objectives:
+      0: Use new Object static methods
+      1: Use new Array static and prototype methods
+      2: Use new String static and prototype methods and properties
+      3: Use new Number static and prototype methods and properties
+      4: Use new Math methods
+      5: Use new RegExp syntax extensions
+  es6-functions:
+    name: Use updates to functions to create more expressive functions
+    description: This standard covers the updates to the function syntax to support more functional programming capabilities in JavaScript.
+    objectives:
+      0: Use Arrow Functions
+      1: Use Generator Functions
+      2: Use parameter defaults
+      3: Use the rest operator ... to capture additional parameters
+  es6-data-structures:
+    name: Use new data structures and their features to store data
+    description: This standard deals with new built-in data structures in JavaScript and their use to effectively store data.
+    objectives:
+      0: Use Set and it's methods to effectively store and retrieve data
+      1: Use Map and it's methods to effectively store and retrieve data
+      2: Use WeakSet and it's methods to effectively store and retrieve data
+      3: Use WeakMap and it's methods to effectively store and retrieve data
+      4: Use Typed Arrays and their methods to effectively store and retrieve data
+      5: Use DataViews and their methods to effectively store and retrieve data
+      6: Use Symbol and it's methods to effectively store and retrieve data
+      7: Use the spread operator (...) to spread a collection
+  destructuring:
+    name: Use destructuring syntax to operate on data in collection
+    description: This standard deals with all forms of destructuring syntax, introduced in ES6.
+    objectives:
+      0: Use destructuring syntax with arrays
+      1: Use destructuring syntax with objects
+      2: Use destructuring syntax to assign default values in objects
+      3: Use destructuring syntax with strings
+      4: Use destructuring syntax with computed property names
+      5: Use destructuring syntax to unpack field names from objects passed as a function parameter
+      6: Use destructuring syntax to iterate over collections
+  es6-class:
+    name: Use prototypes to create class-like objects in JavaScript
+    description: This standard covers using the class and extends keywords, and constructor function with super.
+    objectives:
+      0: Use the class keyword to declare a class, using the constructor function
+      1: Use the extends keyword to inherit from another class, and use super in the constructor function
+  native-promises:
+    name: Use native Promises to manage asynchronous operations
+    description: This standard deals with the use of native promises, and their methods. It does not cover the use of Bluebird, or any other promise library.
+    objectives:
+      0: Use the Promise constructor to create a new promise
+      1: Use .then to await promise resolution
+      2: Use .catch to catch errors
+      3: Use .all to await multiple promises
+      4: Use .resolve to resolve a promise
+      5: Use .reject to reject a promise
+      6: Use .race to race promises
+  async-await:
+    name: Use async await to manage asynchronous operations
+    description: This standard deals with async and await keywords and their use to manage asynchronous operations.
+    objectives:
+      0: Write an async function that performs an asynchronous task
+      1: Use the await keyword to pause execution in an async function until a promise resolves
+  iterators-generators:
+    name: Use iterators and generators to process collections
+    description: This standard deals with the iteration protocol in JavaScript as defined in ES6, and generators, and their use to process a collection or respond dynamically to evented input.
+    objectives:
+      0: Use for..of loops to iterate over a collection by value
+      1: Use generator functions to yield a sequence
+      2: Use a generator to invert control
+      3: Use a generator to manage asynchronous activity by suspending execution until after a promise has resolved
+  es6-proxies:
+    name: Use Proxies to define custom behavior for fundamental operations in JavaScript
+    description: This standard deals with the use of Proxies and Reflect to handle property lookup and assignment, enumeration, and function invocation.
+    objectives:
+      0: Use a Proxy to handle property lookup and assignment
+      1: Use a Proxy to handle function invocation
+      2: Use Reflect to use the internal default behavior of proxy methods
+
+
+
+
 next:
   - javascript:browser-apis

--- a/javascript/node/README.md
+++ b/javascript/node/README.md
@@ -22,5 +22,80 @@ sections:
     - quirks
     - processes-clustering
 
+standards:
+  node-developer-environment:
+    name: Set up and use a Node developer environment
+    description: This standard deals with the ability to set up and install required components of the Node.js Ecosystem
+    objectives:
+      0: Install Node.js on your system
+      1: Manage versions of Node.js with a version manager
+      2: Install a package manager for Node.js
+      3: Install a debugger for Node.js
+      4: Install build tools for Node.js
+      5: Use the node interpreter to execute JavaScript
+  events-asynchronous-operations:
+    name: Use events to manage asynchronous operations
+    description: This standard handles usage of Node's Events API to manage asynchronous operations.
+    objectives:
+      0: Create an EventEmitter
+      1: Listen for events on an EventEmitter
+      2: Emit events on an EventEmitter
+      3: Emit events in response to input to the process
+  use-modules:
+    name: Use modules to add functionality to your code
+    description: This standard deals with importing and exporting modules and using modules.
+    objectives:
+      0: Create a module from a single file with exported functions to reuse code
+      1: Import a module into another file from somewhere else in your project
+      2: Import a module from the npm registry
+      3: Import a module from git
+  read-and-write-streams:
+    name: Read and Write Streams
+    description: This standard deals with streams in Node.js.
+    objectives:
+      0: Use pipe to read from a streaming interface
+      1: Use write to write to a stream
+      2: Use pause and resume effectively to pause and resume streams
+      3: Use stream events to robustly handle a stream's states
+  identify-common-design-patterns:
+    name: Identify and use common design patterns
+    description: This standard deals with the identification of common design patterns in Node.js.
+    objectives:
+      0: Identify and use the factory module design pattern
+      1: Identify and use the middleware pipeline design pattern
+      2: Use conventional property names for common objects
+      3: Use industry conventions to handle synchronous exceptions
+      4: Use industry conventions to handle type errors
+      5: Use industry conventions to catch asynchronous errors
+      6: Identify and use the revealing module pattern
+      7: Use a linter with JavaScript
+      8: Distinguish between operational and programmer error
+  node-standard-library-os:
+    name: Use the standard library to interact with your operating system
+    description: This standard deals with the standard node.js library that exposes operating system features as an API.
+    objectives:
+      0: Use the standard library to interact with the file system
+      1: Use the standard library to issue network requests and listen for responses
+      2: Use the standard library to listen for network requests and issue responses
+      3: Use the standard library to interact with device ports
+      4: Use the standard library to encrypt and decrypt data
+      5: Use the standard library to manage child processes
+      6: Use the standard library to monitor the running process
+  express-server:
+    name: Use express to create a web server
+    description: This standard handles usage of Node's Events API to manage asynchronous operations.
+    objectives:
+      0: Create an express app, bound to a port
+      1: Use an express app to respond to HTTP requests
+      2: Use the express Router to organize route handlers
+      3: Use the express Router & Request object to receive parameters from the URL
+      4: Use middleware with express to parse requests or preprocess responses
+      5: Use parameters from the Request in a route handler
+      6: Use middleware to log incoming requests and outgoing responses
+      7: Use the Response object API to send a properly formatted HTTP response (status code, headers, etc)
+      8: Use a server-side rendering package to render HTML containing data from the server
+      9: Catch server and request errors and properly respond to the request with information about the error
+
+
 next:
   - javascript:npm

--- a/javascript/npm/README.md
+++ b/javascript/npm/README.md
@@ -12,6 +12,48 @@ sections:
     - publishing
     - tools-i
 
+standards:
+  use-open-source-javascript-packages:
+    name: Use open source JavaScript packages
+    description: This standard covers searching for and selecting an open-source JavaScript package from the NPM repository to solve a problem.
+    objectives:
+      0: Search the NPM repository for open-source code to solve a problem
+      1: Distinguish between badly and well maintained packages as a benefit or cost factor
+      2: Assess security vulnerabilities in an open-source JavaScript package as a benefit or cost factor
+      3: Distinguish the effectiveness of documentation in an open-source JavaScript package as a benefit or cost factor
+      4: Distinguish the test coverage of a package as a benefit or cost factor
+      5: Distinguish a package for performance optimization as a benefit or cost factor
+      6: Evaluate a package for it's ability to improve expressiveness as a benefit factor
+      7: Evaluate a package's install size as a cost factor
+      8: Evaluate the licensing of a package as a cost factor
+      9: Evaluate the opinion of the community as a benefit factor
+      10: Evaluate the opinion of the community as a cost factor
+      11: Effectively weigh benefit and cost factors to choose open source packages
+      12: Create a dependency maintenance task to monitor package updates
+  npm-tasks-and-modules-manager:
+    name: Integrate npm as your default tasks and modules manager
+    description: This standard deals with using NPM to handle build tasks and other processes, and use of NPM to handle dependency management.
+    objectives:
+      0: Use package.json to manage dependencies
+      1: Use package.json to manage build scripts
+      2: Use package.json to manage testing
+      3: Use package.json to manage a script toolchain
+  npm-publish:
+    name: Use the npm online repository to publish a module
+    description: This standard deals with creating open-source packages that are considered well maintained.
+    objectives:
+      0: Publish a module to the public NPM registry
+      1: Publish a module to a private NPM registry
+      2: Update a module on an NPM registry
+      3: Use SemVer to version your package
+      4: Use a generated documentation package to document your API
+      5: Write a simple code example for your documentation
+      6: Create a quickstart for your documentation
+      7: Create unit tests for your API
+      8: Create integration tests for your module
+      9: Configure authorship and communication references in your package.json to provide support for your package
+      10: Choose a license for your package
+
 
 next:
   - javascript:react


### PR DESCRIPTION
Todo:
- [ ] create a PR which retriggers all references to these standards from insights/exercises post-deploy

For js/browser-apis:
- there was a standard file not listed in it's manifest - `browser-store-data`. Added the standard between `browser-apis-browser` and `browser-connect-to-remote-hosts` 

For js/es6:
- couldn't find standard file for: "Recognize and employ the features of ECMAScript consistently implemented across V8, Spidermonkey, and Nitro that are not present as of ECMAScript5"
- added `es6-class` (not defined in manifest) after `destructuring`
- added `es6-proxies` (not defined in manifest) after `iterators-generators`

For js/node:
- added `express-server` standard whicih was not included in the manifest

❗️ React is not included as it is still WIP