### PR TITLE
Update reflect-api-in-es6.md

### DIFF
--- a/javascript/ecmascript-2015/master-es6-features/reflect-api-in-es6.md
+++ b/javascript/ecmascript-2015/master-es6-features/reflect-api-in-es6.md
@@ -47,15 +47,6 @@ Reflect.get
     (target, propertyKey, receiver?)
 ```
 
-**Shorten apply**
-
-Produce a cleaner and shorter version of `.apply`.
-```
-Function.prototype.apply.call
-    (func, thisArg, args) // ES5
-Reflect.apply(func, thisArg, args) // ES6
-```
-
 ---
 ## Practice
 


### PR DESCRIPTION
I think this example is misleading because who uses `.apply` that way even with ES5?
Commonly, the call is: `func.apply(thisArg, args)`
And compared to that, using Reflect is less, not more concise.