### PR TITLE
Remove duplicate JS core prototype standard

### DIFF
--- a/javascript/core/README.md
+++ b/javascript/core/README.md
@@ -134,12 +134,6 @@ standards:
       0: Use a constructor function and the execution context of that function to produce an instance with particular properties
       1: Use the prototype of the constructor function to set methods on instances produced by the constructor function
       2: Modify the instance using a prototype method
-  prototype-inherit:
-    name: Use prototypes to create class-like objects in JavaScript
-    description: This standard covers using the prototype of a constructor function to create a class-like object, and inheriting methods and properties from another object higher in the prototype chain, from which instances can be produced that share common methods and properties, but not common property values.
-    objectives:
-      0: Set the prototype of the constructor function to inherit methods on instances produced by the constructor function
-      1: Modify the instance using an inherited prototype's method
   exceptions:
     name: Identify and handle exceptions in JavaScript
     description: This standard deals with exception handling in JavaScript, as well as the identification of different errors that JavaScript displays.

--- a/javascript/core/in-depth-ii/prototype-methods.md
+++ b/javascript/core/in-depth-ii/prototype-methods.md
@@ -15,7 +15,9 @@ category: pattern
 
 standards:
 
-  javascript.prototype-inherit.0: 10
+  javascript.prototype-class.0: 10
+  javascript.prototype-class.1: 10
+
 
 tags:
 

--- a/javascript/ecmascript-2015/classes-modules/js-practice-class-inheritance-i.md
+++ b/javascript/ecmascript-2015/classes-modules/js-practice-class-inheritance-i.md
@@ -13,8 +13,9 @@ link: https://www.codewars.com/kata/fun-with-es6-classes-number-2-animals-and-in
 linkType: codewars
 standards:
 
-  javascript.prototype-inherit.0: 1000
-  javascript.prototype-inherit.1: 1000
+  javascript.prototype-class.0: 1000
+  javascript.prototype-class.1: 1000
+  javascript.prototype-class.2: 1000
 
 links:
 

--- a/javascript/ecmascript-2015/classes-modules/js-practice-class-inheritance-ii.md
+++ b/javascript/ecmascript-2015/classes-modules/js-practice-class-inheritance-ii.md
@@ -16,7 +16,6 @@ standards:
   javascript.prototype-class.0: 1000
   javascript.prototype-class.1: 1000
   javascript.prototype-class.2: 1000
-  javascript.prototype-inherit.0: 1000
 
 links:
 


### PR DESCRIPTION
Both `prototype-class` and `prototype-inherit` cover the same standards, whereas `prototype-class` is more detailed when it comes to objectives.