### PR TITLE
:memo: Use proper YAML notation

### DIFF
--- a/javascript/ecmascript-2015/README.md
+++ b/javascript/ecmascript-2015/README.md
@@ -1,3 +1,4 @@
+---
 name: Ecmascript 2015
 
 description: The sixth edition of Ecmascript. Get up to speed with the new syntax for writing complex applications, including classes, modules, arrow functions and more.
@@ -111,3 +112,4 @@ standards:
 
 next:
   - javascript:browser-apis
+---


### PR DESCRIPTION
We should do this on all PRS (wrap content in `---`).

The [preview is much better this way](https://github.com/enkidevs/curriculum/blob/4fd062282a0c9d76f24483c17804b31d90cecaa5/javascript/ecmascript-2015/README.md) (because it follows the spec of yaml in markdown):