### PR TITLE
Update array-copywithin.md

### DIFF
--- a/javascript/ecmascript-2015/array-updates/array-copywithin.md
+++ b/javascript/ecmascript-2015/array-updates/array-copywithin.md
@@ -77,7 +77,7 @@ alphabet.copyWithin(-2)
 ## Practice
 
 Complete the code example to create an array that looks like this:
-`['7','3','4','5','6','7']`
+`['1','7','3','4','5','6','7']`
 
 ```javascript
 let ints = ['1','2','3','4','5','6','7'];
@@ -85,13 +85,13 @@ ints.copyWithin(???,???,???)
 ```
 
 * 1
-* 2
-* 3
-* 4
-* 5
 * 6
 * 7
 * 8
+* 5
+* 2
+* 3
+* 4
 * 9
 * 0
 


### PR DESCRIPTION
I added a string of '1' in the output array, because of the copyWithin() method shallow copies part of an array to another location in the same array and returns it, without modifying its size. Also, I modified an answer to (1,6,7) -