### PR TITLE
Clarified comparing 'null' and 'undefined'

### DIFF
--- a/javascript/core/types-ii/truthy-falsy-gotchas.md
+++ b/javascript/core/types-ii/truthy-falsy-gotchas.md
@@ -52,7 +52,7 @@ null == false
 //false
 ```
 
-`null` and `undefined` are special and not equal to anything but themselves.
+`null` and `undefined` are special and equal only to themselves and each other.
 
 ... And there are many more of these strange cases so watch out!
 


### PR DESCRIPTION
In this PR I propose changes in wording to Truthy Falsy Gotchas in Javascript Core. Current version led me to think that ` null == undefined` results in `false`


<sub>First PR ever!!! 😸 </sub>