### PR TITLE
Update: curriculum/python/core/control-structures/indentation-and-commenting.md

### DIFF
--- a/python/core/control-structures/indentation-and-commenting.md
+++ b/python/core/control-structures/indentation-and-commenting.md
@@ -73,17 +73,16 @@ print("This line isn't commented out!")
 What will this code print?
 ```
 if True:
-print("this is true")
+   print("this is true")
 else:
-print("this is false")
+   print("this is false")
 
 ```
 ???
 
-* `SyntaxError`
-* `True`
-* `False`
 * `"this is true"`
+* `True`
+* `False
 * `"this is false"`
 
 ---


### PR DESCRIPTION
Make the practice question a bit easier. Remove the "SyntaxError" error, and indent the print statements to change the question to not output an error.