### PR TITLE
Fix practice question

### DIFF
--- a/python/core/functions/calling-functions.md
+++ b/python/core/functions/calling-functions.md
@@ -76,13 +76,12 @@ y = 2
     print((a + b) / 2)
 
 ???(???)
-mean(x, y)
 ```
 
 * def
 * mean
+* x, y
 * (x, y)
-* (a, b)
 
 
 


### PR DESCRIPTION
Syntax `mean((x, y))` is invalid as `(x, y)` is a tuple