### PR TITLE
fix typo in top script example

### DIFF
--- a/python/core/is-your-python-healthy/python-debugger.md
+++ b/python/core/is-your-python-healthy/python-debugger.md
@@ -34,12 +34,12 @@ links:
 
 The **Python debugger** comes as a module called `pdb`, which is part of the **standard Python** distribution.
 
-We will consider a program with two **global variables**, a function that creates a **nested loop** and the `if _name_ == '_main_'` statement that calls the nested loop:
+We will consider a program with two **global variables**, a function that creates a **nested loop** and the `if __name__ == '__main__'` statement that calls the nested loop:
 ```python
 #Program name: debug.py
 
 number_list = [1, 2]  
-chars_list = ['a', 'b']
+chars = ['a', 'b']
 
 def nested_loop():
     for nr in number_list
@@ -47,7 +47,7 @@ def nested_loop():
         for(char in chars)
             print(char)
 
-if _name_ == '_main_':
+if __name_ == '__main__':
     nested_loop()
 ```
 


### PR DESCRIPTION
The script defined at the top of the lesson appears to be different from the script being run with pdb.

1. List `chars_list` is referred to as `chars` inside `nested_function()`. Changed variable declaration to `chars`, following what is shown from `(Pdb) list`. If you'd rather expand the names to have the `_list` suffix it'd need to be changed further down in the pdb example too.
2. Variable `_name_` and string `'_main_'` contain the wrong number of underscores. Changed to have two leading and trailing underscores. (`__name__` and `'__main__'`).

I've tried to look to see if this is intentional (since its a debugging lesson), but it appeared to more likely be a mistake.