### PR TITLE
Fix incorrect example output for python/core/console-and-operators/more-complex-arithmetic-operators.md

### DIFF
--- a/python/core/console-and-operators/more-complex-arithmetic-operators.md
+++ b/python/core/console-and-operators/more-complex-arithmetic-operators.md
@@ -38,7 +38,7 @@ This code executes as 2 to the power of 4.
 Example 2:
 ```python
 >>> -3 ** 4
-81
+-81
 ```
 This code executes as (-3) to the power of 4.
 


### PR DESCRIPTION
Update the correct answer for example 2:
"81" -> "-81"