### PR TITLE
Fixed a typo in the storing-blobs README

### DIFF
--- a/sql/ddl/storing-blobs/README.md
+++ b/sql/ddl/storing-blobs/README.md
@@ -1,4 +1,4 @@
-name: Soring BLOBs in a RDBMS
+name: Storing BLOBs in a RDBMS
 
 type: insights-list
 


### PR DESCRIPTION
Fixing a typo. See:
<img width="291" alt="typo" src="https://user-images.githubusercontent.com/583789/59984958-50a16e00-9669-11e9-86de-2ddcb1cfe7ff.png">
