### PR TITLE
Fix wrong file size "find" command

### DIFF
--- a/linux/user-and-file-management/file-management/using-find-to-search-by-file-size.md
+++ b/linux/user-and-file-management/file-management/using-find-to-search-by-file-size.md
@@ -39,7 +39,7 @@ The `find` command is used to search for files on your computer.  It's often use
 This will find all files at least 50MB or larger in the current directory:
 
 ```shell
-$ find . -type f -size +50M
+$ find . -type f -size +100M
 ```
 
 The `+` in `+100M` signifies "at least 100MB".  If instead we used `-size 100MB`, `find` would only match files which are 100MB large (rounded to the nearest MB).

--- a/linux/user-and-file-management/file-management/using-find-to-search-by-file-size.md
+++ b/linux/user-and-file-management/file-management/using-find-to-search-by-file-size.md
@@ -36,7 +36,7 @@ aspects:
 
 The `find` command is used to search for files on your computer.  It's often useful to search for files by file size, e.g., if you want to find potentially large files to delete.
 
-This will find all files at least 50MB or larger in the current directory:
+This will find all files at least 100MB or larger in the current directory:
 
 ```shell
 $ find . -type f -size +100M


### PR DESCRIPTION
The command to find files above 100MB in size was wrong. It found files above 50MB instead.