### PR TITLE
Update the-abstract-keyword.md

### DIFF
--- a/java/fundamentals/abstract-keyword/the-abstract-keyword.md
+++ b/java/fundamentals/abstract-keyword/the-abstract-keyword.md
@@ -61,7 +61,7 @@ It is worth noting that methods in an interface are implicitly `abstract`, so it
 ## Practice
 
 Which of the following is a properly declared abstract method? 
-```java
+```
 abstract String optionX[String s]; 
 abstract String optionY{String s);   
 abstract String optionZ(String s);
@@ -76,7 +76,7 @@ abstract String optionZ(String s);
 ## Revision
 
 Which of the following is a properly declared abstract method?
-```java
+```
 abstract float optionA(float e);    
 abstract float optionB(float e) {};
 abstract float optionC(float e) {


### PR DESCRIPTION
Remove the Java Code identifiers in both PQ and RQ because it makes the correct answers colored within the example differently than the 2 wrong answers