### PR TITLE
Fix typo in python/core/classes-i/using-classes.md

### DIFF
--- a/python/core/classes-i/using-classes.md
+++ b/python/core/classes-i/using-classes.md
@@ -20,7 +20,7 @@ standards:
 ---
 ## Content
 
-To use a class, you must create an instance of a class. Take the previous class:
+To use a class, you must create an instance of a class. Take the following class:
 ```python
 class Employee:
   count = 0


### PR DESCRIPTION
Phrase said "Take the previous class:" and it was changed to "Take the following class:"