### PR TITLE
Fix content error

### DIFF
--- a/javascript/ecmascript-2015/spread-map-set-math/map-data-structure.md
+++ b/javascript/ecmascript-2015/spread-map-set-math/map-data-structure.md
@@ -110,7 +110,7 @@ const myMap = new Map()
 
 myMap.???(???, 'enki')
 console.log(myMap)
-// Map(1) {1 => "enki"}
+// Map(4) {4 => "enki"}
 
 console.log(myMap.???(4))
 // true


### PR DESCRIPTION
For the revision question, the comments were wrong:
- old

```
myMap.set(4, 'enki')
console.log(myMap)
// Map(1) {1 => "enki"}
```

- new

```
myMap.set(4, 'enki')
console.log(myMap)
// Map(4) {4 => "enki"}
```