### PR TITLE
Improve string flexibility workout

### DIFF
--- a/javascript/ecmascript-2015/string-flexibility/string-raw.md
+++ b/javascript/ecmascript-2015/string-flexibility/string-raw.md
@@ -26,7 +26,7 @@ links:
 
 `String.raw` is used to work with template strings and is best explained with an example:
 
-In JavaScript **\n** is used to indicate a new line.
+In JavaScript `\n` is used to indicate a new line.
 
 Consider if we had the following template literal:
 
@@ -34,14 +34,14 @@ Consider if we had the following template literal:
 `Line1\nLine2!`;
 ```
 
-When output this would be interpreted as below as \n signifies a new line:
+When output this would be interpreted as below as `\n` signifies a new line:
 
 ```bash
 "Line1
 Line2"
 ```
 
-However sometimes it is desirable to work with a string template in its raw format - **String.raw** allows you to do this - note how there is no new line between Line1 and Line2 now just \n:
+However sometimes it is desirable to work with a string template in its raw format - `String.raw` allows you to do this - note how there is no new line between Line1 and Line2 now, just `\n`:
 
 ```javascript
 String.raw`Line1\nLine2`;

--- a/javascript/ecmascript-2015/string-flexibility/string-raw.md
+++ b/javascript/ecmascript-2015/string-flexibility/string-raw.md
@@ -34,14 +34,14 @@ Consider if we had the following template literal:
 `Line1\nLine2!`;
 ```
 
-When output this would be interpreted as below as `\n` signifies a new line:
+When executed, the code above would treat `\n` as a new line and produce:
 
 ```bash
 "Line1
 Line2"
 ```
 
-However sometimes it is desirable to work with a string template in its raw format - `String.raw` allows you to do this - note how there is no new line between Line1 and Line2 now, just `\n`:
+However sometimes it is desirable to work with a string template in its raw format (without interpretation of escaped characters) - `String.raw` allows you to do this - note how there is no new line between Line1 and Line2 now, just `\n`:
 
 ```javascript
 String.raw`Line1\nLine2`;

--- a/javascript/ecmascript-2015/string-flexibility/tagged-template-literals.md
+++ b/javascript/ecmascript-2015/string-flexibility/tagged-template-literals.md
@@ -64,7 +64,7 @@ I am a multiline string
 `;
 ```
 
-Beyond variables, template literals actually allow us to interpolate any JavaScript expression, for example `${5 + 5}`. The expression will be cast to a string, then replaced inside the template string.
+Beyond variables, template literals actually allow us to interpolate *any* JavaScript expression, for example `${5 + 5}`. The expression will be cast to a string, then replaced inside the template string.
 
 ```js
 let item = "Oranges";

--- a/javascript/ecmascript-2015/string-flexibility/tagged-template-literals.md
+++ b/javascript/ecmascript-2015/string-flexibility/tagged-template-literals.md
@@ -47,6 +47,9 @@ aspects:
 ES6 introduced a new feature called template strings that make it easier to work with strings by adding string interpolation and multi-line strings:
 
 ```js
+// string interpolation
+// is a fancy word for
+// variable substitution
 let company = "Enki";
 console.log(`Hello ${company}!`);
 //prints: "Hello Enki!"
@@ -61,7 +64,7 @@ I am a multiline string
 `;
 ```
 
-As well as embedding _any_ JavaScript expression inside of a pair of curly braces prefixed by a dollar sign: `${5 + 5}`. The expression will be cast to a string, then replaced inside the template string.
+Beyond variables, template literals actually allow us to interpolate any JavaScript expression, for example `${5 + 5}`. The expression will be cast to a string, then replaced inside the template string.
 
 ```js
 let item = "Oranges";

--- a/javascript/ecmascript-2015/string-flexibility/tagged-template-literals.md
+++ b/javascript/ecmascript-2015/string-flexibility/tagged-template-literals.md
@@ -44,43 +44,41 @@ aspects:
 ---
 ## Content
 
-ES6 introduces a new feature called template strings that make it easier to work with strings by adding string interpolation and multi-line strings:
+ES6 introduced a new feature called template strings that make it easier to work with strings by adding string interpolation and multi-line strings:
 
-```
+```js
 let company = "Enki";
 console.log(`Hello ${company}!`);
 //prints: "Hello Enki!"
 ```
 
-Template literals are denoted by the O&#769; character, rather than `''` or `""`. When you use template strings, you can have multiline strings:
+Template literals are denoted by the `` ` `` character, rather than `''` or `""`. When you use template strings, you can have multiline strings:
 
-```
-
+```js
 let aMultilineString = `
 Hello
 I am a multiline string
-`
-
+`;
 ```
 
 As well as embedding _any_ JavaScript expression inside of a pair of curly braces prefixed by a dollar sign: `${5 + 5}`. The expression will be cast to a string, then replaced inside the template string.
 
-```
+```js
 let item = "Oranges";
-let itemPrice = 2.50;
+let itemPrice = 2.5;
 let money = 10;
 let compositeString = `Hi,
 I have ${money} dollars,
 and I would like to purchase :
 ${itemPrice / money} ${item}s.
-`
+`;
 
 console.log(compositeString);
 ```
 
 The above would output:
 
-```
+```js
 Hi,
 I have 10 dollars,
 and I would like to purchase :


### PR DESCRIPTION
tagged-template-literals.md
- changed bold functions to be contained by backticks
- changed first phrase to 'ES6 introduced...'
- fixed? the backtick display between backticks

string-raw.md
- changed bold functions to be contained by backticks