### PR TITLE
Fix content error in python

### DIFF
--- a/python/core/console-and-operators/more-complex-arithmetic-operators.md
+++ b/python/core/console-and-operators/more-complex-arithmetic-operators.md
@@ -38,9 +38,16 @@ This code executes as 2 to the power of 4.
 Example 2:
 ```python
 >>> -3 ** 4
--81
+81
 ```
-This code executes as (-3) to the power of 4.
+This code executes as -(3 to the power of 4). The reasoning behind this is that the `**` operator has higher precedence than the `-` operator. This table presents the mathematical operators ordered by their precedence:
+
+| Operator | Description                         |
+|:--------:|-------------------------------------|
+|    ()    | Parentheses(grouping)               |
+|    **    | Exponentiation                      |
+|  *, /, % | Multiplication, division, remainder |
+|   +, -   | Addition, subtraction               |
 
 Python also supports the modulo operator, `%`, which is used to return the integer remainder of a division sum.
 

--- a/python/core/console-and-operators/more-complex-arithmetic-operators.md
+++ b/python/core/console-and-operators/more-complex-arithmetic-operators.md
@@ -44,8 +44,11 @@ Example 2:
 ```python
 >>> -3 ** 4
 -81
+>>> 2 ** -2
+0.25
 ```
-This code executes as -(3 to the power of 4). If you want to learn more about the order in which operations are executed make sure to check out the resources for this insight.
+
+The first expression executes as `-(3 ** 4)` and the second one as `2 ** (-2)`. Even though the precedence of the `-` and `+` operators is higher than that of the exponentiation operator `**`, the operator `**` binds less tightly than the operator on it's right and more tightly than the operator on it's left. Thus, the unary operator `-` of `-3` is executed on the result of the `3 ** 4` expression.
 
 Python also supports the modulo operator, `%`, which is used to return the integer remainder of a division sum.
 

--- a/python/core/console-and-operators/more-complex-arithmetic-operators.md
+++ b/python/core/console-and-operators/more-complex-arithmetic-operators.md
@@ -19,6 +19,11 @@ aspects:
 standards:
   python.native-types-operations.2: 10
 
+links: 
+  
+  - '[operator-precedence](https://docs.python.org/3/reference/expressions.html#operator-precedence){documentation}'
+
+
 ---
 
 # More Complex Arithmetic Operators
@@ -38,16 +43,9 @@ This code executes as 2 to the power of 4.
 Example 2:
 ```python
 >>> -3 ** 4
-81
+-81
 ```
-This code executes as -(3 to the power of 4). The reasoning behind this is that the `**` operator has higher precedence than the `-` operator. This table presents the mathematical operators ordered by their precedence:
-
-| Operator | Description                         |
-|:--------:|-------------------------------------|
-|    ()    | Parentheses(grouping)               |
-|    **    | Exponentiation                      |
-|  *, /, % | Multiplication, division, remainder |
-|   +, -   | Addition, subtraction               |
+This code executes as -(3 to the power of 4). If you want to learn more about the order in which operations are executed make sure to check out the resources for this insight.
 
 Python also supports the modulo operator, `%`, which is used to return the integer remainder of a division sum.
 


### PR DESCRIPTION
Fixed an example which stated `-(3 ** 4) = -81` when in reality it is `-(3 ** 4) = 81` due to operator precedence. Also added a table which orders mathematical operators by their precedence.