### PR TITLE
Update searching-array-methods.md

### DIFF
--- a/javascript/ecmascript-2015/array-updates/searching-array-methods.md
+++ b/javascript/ecmascript-2015/array-updates/searching-array-methods.md
@@ -71,13 +71,13 @@ var people = [
 ];
 
 people.find(function(e, i, src) {
-  return element.age >= 18;
+  return e.age >= 18;
 });
 //returns Alex
 
 people.findIndex(function(e, i, src) {
   return (
-    element.age > 18 && element.age < 30
+    e.age > 18 && e.age < 30
   );
 });
 //returns 1


### PR DESCRIPTION
"element" is used in the return statements instead of "e" as defined.