### PR TITLE
Improve props-II in React

### DIFF
--- a/javascript/react/props-ii/children-in-react.md
+++ b/javascript/react/props-ii/children-in-react.md
@@ -28,7 +28,7 @@ aspects:
 
 ---
 
-# Children in **React**
+# Children in React
 
 ---
 ## Content
@@ -43,11 +43,10 @@ It can be used to access the `children` of any parent component from within it.
 <Wrapper>
   <A />
   <B />
-</Wrapper>
+</Wrapper>;
 
 // <A /> and <B /> are the children of
 // <Wrapper>
-
 ```
 
 Keep in mind that a `component` can have a **single** child / **no** children, but also an **array** of children.
@@ -56,22 +55,17 @@ You can make use of `props.children` to dynamically render `component`s and `ele
 
 Consider the following component:
 ```jsx
-class Wrapper extends React.Component{
-	render() {
-  	return (
-    	<div>
-      	{this.props.children}
-      </div>
-    );
+class Wrapper extends React.Component {
+  render() {
+    return <div>{this.props.children}</div>;
   }
 }
-
 ```
 Our component will render nothing but the enclosed `<div>` in the following scenario:
 ```jsx
 ReactDOM.render(
   <Wrapper></Wrapper>,
-  document.getElementById('root')
+  document.getElementById("root")
 );
 ```
 
@@ -94,18 +88,17 @@ The `React.Children` class provides a bunch of methods useful for iterating and 
 What will be rendered within the `div` with `id="main"`?
 ```jsx
 function Exercise(props) {
-	return (
-  	<div id="main">
-  		{props.children}
-  	</div>
-    );
+  return (
+    <div id="main">{props.children}</div>
+  );
 }
 
 ReactDOM.render(
-  <Exercise><h1>Main</h1></Exercise>,
-  document.getElementById('root')
+  <Exercise>
+    <h1>Main</h1>
+  </Exercise>,
+  document.getElementById("root")
 );
-
 ```
 
 `???`

--- a/javascript/react/props-ii/children-in-react.md
+++ b/javascript/react/props-ii/children-in-react.md
@@ -43,7 +43,7 @@ It can be used to access the `children` of any parent component from within it.
 <Wrapper>
   <A />
   <B />
-</Wrapper>;
+</Wrapper>
 
 // <A /> and <B /> are the children of
 // <Wrapper>

--- a/javascript/react/props-ii/dealing-with-this-props-children.md
+++ b/javascript/react/props-ii/dealing-with-this-props-children.md
@@ -32,7 +32,7 @@ aspects:
 
 `map` creates a new collection of children by invoking a function on every immediate child:
 
-```jsx
+```js
 React.Children.map(
   children, 
   functionToCallOnEachChild
@@ -43,7 +43,7 @@ Keep in mind that if `children` is a nested object or an array it will be traver
 
 `forEach` works similarly to `map`, where it also iterates on each child but this time it ignores the returned value of its callback and doesn't create a new collection:
 
-```jsx
+```js
 React.Children.forEach(
   children, 
   functionToCallOnEachChild
@@ -52,7 +52,7 @@ React.Children.forEach(
 
 Return the total number of components in `children`:
 
-```jsx
+```js
 React.Children.count(
   children
 )
@@ -60,7 +60,7 @@ React.Children.count(
 
 Return the only child in `children`:
 
-```jsx
+```js
 React.Children.only(
   children
 )
@@ -68,7 +68,7 @@ React.Children.only(
 
 Manipulate a collection of `children` by converting it into an array:
 
-```jsx
+```js
 React.Children.toArray(
   children
 )

--- a/javascript/react/props-ii/dealing-with-this-props-children.md
+++ b/javascript/react/props-ii/dealing-with-this-props-children.md
@@ -33,7 +33,10 @@ aspects:
 `map` invokes a function on every immediate child within `children`, returning an array:
 
 ```jsx
-React.Children.map(children, function[(thisArg)])
+React.Children.map(
+  children, 
+  function[(thisArg)]
+)
 ```
 
 Keep in mind that if `children` is a nested object or an array it will be traversed and also that `function` will never be passed to the container objects.
@@ -41,25 +44,34 @@ Keep in mind that if `children` is a nested object or an array it will be traver
 `forEach` works like `map`, yet it does not return an array:
 
 ```jsx
-React.Children.forEach(children, function[(thisArg)])
+React.Children.forEach(
+  children, 
+  function[(thisArg)]
+)
 ```
 
 Return the total number of components in `children`:
 
 ```jsx
-React.Children.count(children)
+React.Children.count(
+  children
+)
 ```
 
 Return the only child in `children`:
 
 ```jsx
-React.Children.only(children)
+React.Children.only(
+  children
+)
 ```
 
 Manipulate collections of `children` by converting them into arrays:
 
 ```jsx
-React.Children.toArray(children)
+React.Children.toArray(
+  children
+)
 ```
 
 Now, let's see how you can use these in your code. Let's start by creating a component that counts the total number of children:

--- a/javascript/react/props-ii/dealing-with-this-props-children.md
+++ b/javascript/react/props-ii/dealing-with-this-props-children.md
@@ -30,23 +30,23 @@ aspects:
 
 **React** provides the user with the useful class `React.Children` which provides various utilities for dealing with the opaque data structure `this.props.children`.
 
-`map` invokes a function on every immediate child within `children`, returning an array:
+`map` creates a new collection of children by invoking a function on every immediate child:
 
 ```jsx
 React.Children.map(
   children, 
-  function[(thisArg)]
+  functionToCallOnEachChild
 )
 ```
 
 Keep in mind that if `children` is a nested object or an array it will be traversed and also that `function` will never be passed to the container objects.
 
-`forEach` works like `map`, yet it does not return an array:
+`forEach` works similarly to `map`, where it also iterates on each child but this time it ignores the returned value of its callback and doesn't create a new collection:
 
 ```jsx
 React.Children.forEach(
   children, 
-  function[(thisArg)]
+  functionToCallOnEachChild
 )
 ```
 
@@ -66,7 +66,7 @@ React.Children.only(
 )
 ```
 
-Manipulate collections of `children` by converting them into arrays:
+Manipulate a collection of `children` by converting it into an array:
 
 ```jsx
 React.Children.toArray(

--- a/javascript/react/props-ii/dealing-with-this-props-children.md
+++ b/javascript/react/props-ii/dealing-with-this-props-children.md
@@ -31,30 +31,76 @@ aspects:
 **React** provides the user with the useful class `React.Children` which provides various utilities for dealing with the opaque data structure `this.props.children`.
 
 `map` invokes a function on every immediate child within `children`, returning an array:
-```javascript
-array React.Children.map(object children,
-  function fn[, object thisArg]);
+
+```jsx
+React.Children.map(children, function[(thisArg)])
 ```
-Keep in mind that if `children` is a nested object or an array it will be traversed and also that `fn` will never be passed the container objects.
+
+Keep in mind that if `children` is a nested object or an array it will be traversed and also that `function` will never be passed to the container objects.
 
 `forEach` works like `map`, yet it does not return an array:
-```javascript
-React.Children.forEach(object children,
-  function fn(, object thisArg]);
+
+```jsx
+React.Children.forEach(children, function[(thisArg)])
 ```
+
 Return the total number of components in `children`:
-```javascript
-number React.Children.count(object children)
+
+```jsx
+React.Children.count(children)
 ```
 
 Return the only child in `children`:
-```javascript
-object React.Children.only(object children);
+
+```jsx
+React.Children.only(children)
 ```
+
 Manipulate collections of `children` by converting them into arrays:
-```javascript
-array React.Children.toArray(object
-  children);
+
+```jsx
+React.Children.toArray(children)
+```
+
+Now, let's see how you can use these in your code. Let's start by creating a component that counts the total number of children:
+
+```jsx
+class CountChildren extends React.Component {
+  render() {
+    return (
+      <p>
+        {React.Children.count(
+          this.props.children
+        )}
+      </p>
+    );
+  }
+}
+
+ReactDOM.render(
+  <CountChildren>
+    <h1>I am the first child</h1>
+    <h2>And I am the second child</h2>
+  </CountChildren>,
+  document.getElementById("root")
+);
+// Renders "2"
+```
+
+If you wanted to return only the first 5 children, you could use:
+
+```jsx
+class LimitChildren extends React.Component {
+  render() {
+    return React.Children.map(
+      this.props.children,
+      (child, i) => {
+        if (i <= 5) return child;
+        return null;
+      }
+    );
+  }
+}
 ```
 
 ---

--- a/javascript/react/props-ii/dealing-with-this-props-children.md
+++ b/javascript/react/props-ii/dealing-with-this-props-children.md
@@ -90,7 +90,7 @@ ReactDOM.render(
 If you wanted to return only the first 5 children, you could use:
 
 ```jsx
-class LimitChildren extends React.Component {
+class LimitChildren extends React.Component{
   render() {
     return React.Children.map(
       this.props.children,

--- a/javascript/react/props-ii/dealing-with-this-props-children.md
+++ b/javascript/react/props-ii/dealing-with-this-props-children.md
@@ -65,7 +65,7 @@ React.Children.toArray(children)
 Now, let's see how you can use these in your code. Let's start by creating a component that counts the total number of children:
 
 ```jsx
-class CountChildren extends React.Component {
+class CountChildren extends React.Component{
   render() {
     return (
       <p>

--- a/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
+++ b/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
@@ -28,7 +28,7 @@ Passing down props from the parent to generate state in `getInitialState` can le
 
 An example of a duplication of source of truth:
 
-```javascript
+```jsx
 class Duplication extends React.Component {
   getInitialState() {
     return {
@@ -50,7 +50,7 @@ This is bad due to `constructor` being invoked when the component is first creat
 
 Computing values on-the-fly ensures that values don't get out of sync later and cause maintenance issues.
 
-```javascript
+```jsx
 class OnTheFly extends React.Component {
   render() {
     return (
@@ -84,7 +84,7 @@ What do you think about generating state from props in `getInitialState`?
 
 Which of the following two components do you think employs the best practice for passing props?
 
-```javascript
+```jsx
 class A extends React.Component {
   getInitialState() {
     return {

--- a/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
+++ b/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
@@ -46,7 +46,7 @@ class Duplication extends React.Component {
 }
 ```
 
-This is bad due to `getInitialState` being invoked when the component is first created, therefore the example allows a value to get out of sync.
+This is bad due to `constructor` being invoked when the component is first created, therefore the example allows a value to get out of sync.
 
 Computing values on-the-fly ensures that values don't get out of sync later and cause maintenance issues.
 

--- a/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
+++ b/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
@@ -30,12 +30,14 @@ An example of a duplication of source of truth:
 
 ```jsx
 class Duplication extends React.Component {
-  getInitialState() {
-    return {
+  constructor(props) {
+    super(props);
+    this.state = {
       nameWithQualifier:
         "Country " + this.props.country
     };
   }
+
   render() {
     return (
       <div>

--- a/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
+++ b/javascript/react/props-ii/props-in-getinitialstate-is-an-anti-pattern.md
@@ -29,19 +29,21 @@ Passing down props from the parent to generate state in `getInitialState` can le
 An example of a duplication of source of truth:
 
 ```javascript
-var Duplication = React.createClass({
-  getInitialState: function() {
+class Duplication extends React.Component {
+  getInitialState() {
     return {
-      nameWithQualifier: 'Country ' +
-        this.props.country
+      nameWithQualifier:
+        "Country " + this.props.country
     };
   }
-  render: function() {
-    return <div>
-      {this.state.nameWithQualifier}
-    </div>;
+  render() {
+    return (
+      <div>
+        {this.state.nameWithQualifier}
+      </div>
+    );
   }
-});
+}
 ```
 
 This is bad due to `getInitialState` being invoked when the component is first created, therefore the example allows a value to get out of sync.
@@ -49,17 +51,19 @@ This is bad due to `getInitialState` being invoked when the component is first c
 Computing values on-the-fly ensures that values don't get out of sync later and cause maintenance issues.
 
 ```javascript
-var OnTheFly = React.createClass({
-  render: function() {
-    return <div>{
-      'Country: ' + this.props.country
-    }</div>;
+class OnTheFly extends React.Component {
+  render() {
+    return (
+      <div>
+        {"Country: " + this.props.country}
+      </div>
+    );
   }
-});
+}
 
 ReactDOM.render(
   <OnTheFly country="England" />,
-  document.getElementByID('foo')
+  document.getElementByID("foo")
 );
 ```
 
@@ -81,27 +85,22 @@ What do you think about generating state from props in `getInitialState`?
 Which of the following two components do you think employs the best practice for passing props?
 
 ```javascript
-var A = React.createClass({
-  getInitialState: function() {
+class A extends React.Component {
+  getInitialState() {
     return {
       myState: this.props.myProp
     };
   }
-  render: function() {
-    return <div>
-      {this.state.myState}
-    </div>;
+  render() {
+    return <div>{this.state.myState}</div>;
   }
-});
+}
 
-var B = React.createClass({
-  render: function() {
-    return <div>{
-      this.props.myProp
-    }</div>;
+class B extends React.Component {
+  render() {
+    return <div>{this.props.myProp}</div>;
   }
-});
-
+}
 ```
 
 ???

--- a/javascript/react/props-ii/specify-a-single-child.md
+++ b/javascript/react/props-ii/specify-a-single-child.md
@@ -31,7 +31,7 @@ aspects:
 ---
 ## Content
 
-Making use of the `propTypes`, you can enforce a *warning* that is fired when you pass more than one child to a component.
+Making use of the `propTypes`, you can show a *warning* or throw an *error*, when you pass more than one child to a component.
 
 The validator used is `PropTypes.element`.
 
@@ -44,7 +44,7 @@ class NewComponent extends React.Component {
 }
 ```
 
-To make sure `this.props.children` is **exactly** a single element, we suffix the validation with `isRequired`:
+To throw an error if anything but exactly 1 element is passed as `children`, we suffix the `PropTypes` validation with `isRequired`:
 ```jsx
 NewComponent.propTypes = {
   children: PropTypes.element.isRequired

--- a/javascript/react/props-ii/specify-a-single-child.md
+++ b/javascript/react/props-ii/specify-a-single-child.md
@@ -45,7 +45,7 @@ class NewComponent extends React.Component {
 ```
 
 To throw an error if anything but exactly 1 element is passed as `children`, we suffix the `PropTypes` validation with `isRequired`:
-```jsx
+```js
 NewComponent.propTypes = {
   children: PropTypes.element.isRequired
 };
@@ -56,7 +56,7 @@ NewComponent.propTypes = {
 
 What validator must be used to make sure there is exactly one child passed to `children`?
 
-```jsx
+```js
 children: PropTypes.???.???,
 ```
 
@@ -74,7 +74,7 @@ children: PropTypes.???.???,
 
 What validator must be used to make sure there is exactly one child passed to `children`?
 
-```jsx
+```js
 children: PropTypes.???.???,
 ```
 

--- a/javascript/react/props-ii/specify-a-single-child.md
+++ b/javascript/react/props-ii/specify-a-single-child.md
@@ -31,32 +31,24 @@ aspects:
 ---
 ## Content
 
-Making use of the `propTypes` you can enforce a *warning* fired when you pass more than one child to a component as children.
+Making use of the `propTypes`, you can enforce a *warning* that is fired when you pass more than one child to a component.
 
-The validator used is `React.PropTypes.element`.
+The validator used is `PropTypes.element`.
 
-Suppose the following scenario:
+Suppose we have the following scenario:
 ```jsx
-React.createClass({
-  //propTypes
-
-  render: function() {
-    return (
-      <div>
-        {this.props.children}
-      </div>
-    );
+class NewComponent extends React.Component {
+  render() {
+    return <div>{this.props.children}</div>;
   }
-});
+}
 ```
 
-To make sure `this.props.children` is **exactly** a single element we suffix the validation with `isRequired`:
+To make sure `this.props.children` is **exactly** a single element, we suffix the validation with `isRequired`:
 ```jsx
-propTypes: {
-  children:
-     React.PropTypes.element.isRequired,
-}
-
+NewComponent.propTypes = {
+  children: PropTypes.element.isRequired
+};
 ```
 
 ---
@@ -65,7 +57,7 @@ propTypes: {
 What validator must be used to make sure there is exactly one child passed to `children`?
 
 ```jsx
-children: React.PropTypes.???.???,
+children: PropTypes.???.???,
 ```
 
 
@@ -83,7 +75,7 @@ children: React.PropTypes.???.???,
 What validator must be used to make sure there is exactly one child passed to `children`?
 
 ```jsx
-children: React.PropTypes.???.???,
+children: PropTypes.???.???,
 ```
 
 

--- a/javascript/react/props-ii/type-of-the-children-props.md
+++ b/javascript/react/props-ii/type-of-the-children-props.md
@@ -31,30 +31,34 @@ When there is a single child, `this.props.children` will be the the single child
 
 The example shows both with and without an array allocation:
 
-```javascript
-var Wrapper = React.createClass({
-  componentDidMount: function() {
+```jsx
+class Wrapper extends React.Component {
+  componentDidMount() {
     console.log(
       Array.isArray(this.props.children)
     );
   }
-  render: function() {
-      return <div />;
+
+  render() {
+    return <div />;
   }
-});
+}
 
 // an array of components
 ReactDOM.render(
-  <Wrapper><span/><span/>
-         <span/></Wrapper>,
-  document.getElementById('foo')
+  <Wrapper>
+    <span />
+    <span />
+    <span />
+  </Wrapper>,
+  document.getElementById("foo")
 );
 // true
 
 // single child (no array allocation)
 ReactDOM.render(
   <Wrapper>hello</Wrapper>,
-  document.getElementById('foo2')
+  document.getElementById("foo2")
 );
 // false
 ```
@@ -65,36 +69,41 @@ ReactDOM.render(
 Consider the following react component:
 
 ```javascript
-var Enki = React.createClass({
-  componentDidMount: function {
-    console.log(this.props.children)
+class Enki extends React.Component {
+  componentDidMount() {
+    console.log(this.props.children);
   }
-  render: function() {
+  render() {
     return <div />;
   }
-})
+}
 ```
 
 What will the following output?
 
 ```javascript
 ReactDOM.render(
-  <Enki><p/><p/></Enki>,
+  <Enki>
+    <p />
+    <p />
+  </Enki>,
   aNode
 );
 // ???
 
 ReactDOM.render(
-  <Enki><p/></Enki>,
+  <Enki>
+    <p />
+  </Enki>,
   aSecondNode
 )
 // ???
 ```
 
-* `[<p/> <p/>]`
-* `<p/>`
-* `[ <p/>]`
-* `<p/>, <p/>`
+* `[<p />, <p />]`
+* `<p />`
+* `[<p />]`
+* `<p />, <p />`
 * null
 * undefined
 

--- a/javascript/react/props-ii/type-of-the-children-props.md
+++ b/javascript/react/props-ii/type-of-the-children-props.md
@@ -68,7 +68,7 @@ ReactDOM.render(
 
 Consider the following react component:
 
-```javascript
+```jsx
 class Enki extends React.Component {
   componentDidMount() {
     console.log(this.props.children);
@@ -81,7 +81,7 @@ class Enki extends React.Component {
 
 What will the following output?
 
-```javascript
+```jsx
 ReactDOM.render(
   <Enki>
     <p />


### PR DESCRIPTION
2. dealing with this.props.children:
- updated syntax to latest version
- added example of how to create a component that counts children
- added example of component that only returns the first 5 children

3. type of the children props:
- updated syntax to the latest version
- improved formatting of code blocks

4. specify a single child:
- updated syntax to the latest version

5. props in getInitialState is an anti-patter:
- updated syntax to the latest version