### PR TITLE
Fix footnote in git-ignore.md

### DIFF
--- a/git/essentials/features-i/git-ignore.md
+++ b/git/essentials/features-i/git-ignore.md
@@ -80,6 +80,4 @@ What file is used to tell git to ignore certain files in your project?
 ---
 ## Footnotes
 [1: Dot-files]
-
 By convention, a "dot-file" (a file name which begins with `.`) is hidden and extra steps are required for it to be displayed in the file explorer.
- 


### PR DESCRIPTION
In this insight, the Footnotes are defined correctly, but in the insight just `[1]` is displayed. I suspect this is due to the space between `[1: text]` and the actual text of the footnote.