### PR TITLE
Fix footnote in git-ignore.md

### DIFF
--- a/git/essentials/features-i/git-ignore.md
+++ b/git/essentials/features-i/git-ignore.md
@@ -79,5 +79,6 @@ What file is used to tell git to ignore certain files in your project?
 
 ---
 ## Footnotes
+
 [1: Dot-files]
 By convention, a "dot-file" (a file name which begins with `.`) is hidden and extra steps are required for it to be displayed in the file explorer.


### PR DESCRIPTION
The footnote is not displayed correctly in the insight. This is an attempt to fix it.

![image](https://user-images.githubusercontent.com/19802557/64249094-c730d680-cf0a-11e9-8be4-8e249789d9e6.png)
