### PR TITLE
remove non-existing category from `py-practice-stacks.md`

### DIFF
--- a/python/core/more-on-lists/py-practice-stacks.md
+++ b/python/core/more-on-lists/py-practice-stacks.md
@@ -18,7 +18,7 @@ aspects:
   - deep
 
 type: exercise
-category: good practice
+category: best practice
 
 links:
 

--- a/python/functional-programming/arrays-i/py-practice-functional-features.md
+++ b/python/functional-programming/arrays-i/py-practice-functional-features.md
@@ -16,7 +16,7 @@ aspects:
 
 
 type: exercise
-category: good practice
+category: best practice
 
 links:
 

--- a/python/functional-programming/functional-programming/py-practice-functional-features2.md
+++ b/python/functional-programming/functional-programming/py-practice-functional-features2.md
@@ -15,7 +15,7 @@ aspects:
   - deep
 
 type: exercise
-category: good practice
+category: best practice
 
 links:
 

--- a/python/functional-programming/functional-programming/py-practice-functional-imperative.md
+++ b/python/functional-programming/functional-programming/py-practice-functional-imperative.md
@@ -11,7 +11,7 @@ levels:
 
 type: exercise
 
-category: good practice
+category: best practice
 aspects:
   - introduction
   - workout

--- a/python/functional-programming/functional-programming/py-practice-functional-programming2.md
+++ b/python/functional-programming/functional-programming/py-practice-functional-programming2.md
@@ -10,7 +10,7 @@ levels:
   - medium
 
 type: exercise
-category: good practice
+category: best practice
 aspects:
   - introduction
   - workout

--- a/python/functional-programming/generators/py-practice-generators.md
+++ b/python/functional-programming/generators/py-practice-generators.md
@@ -11,7 +11,7 @@ levels:
 
 
 type: exercise
-category: good practice
+category: best practice
 aspects:
   - introduction
   - workout


### PR DESCRIPTION
Use the correct category "best practice" instead of the non-existing "good practice"