### PR TITLE
Remove broken link from owasp-top-ten.md

### DIFF
--- a/security/appsec/intro/owasp-top-ten.md
+++ b/security/appsec/intro/owasp-top-ten.md
@@ -23,7 +23,6 @@ links:
   - '[OWASP](https://www.owasp.org/)'
   - '[2017 OWASP Top Ten](https://www.owasp.org/images/7/72/OWASP_Top_10-2017_%28en%29.pdf.pdf)'
   - '[Common Vulnerabilities and Exposures Database](https://cve.mitre.org/)'
-  - '[Cryptography and Security on Arxiv](https://arxiv.org/list/cs.CR/recent)'
 
 ---
 


### PR DESCRIPTION
One of the links was not working, as it was reported by a [user](https://enkilabs.slack.com/archives/CLESV59ME/p1568216345004500). I have removed said link.