### PR TITLE
Common mistakes in React

### DIFF
--- a/javascript/react/README.md
+++ b/javascript/react/README.md
@@ -17,3 +17,4 @@ sections:
     - props-iii
     - redux-i
     - redux-tips
+    - common-mistakes-in-react

--- a/javascript/react/common-mistakes-in-react/README.md
+++ b/javascript/react/common-mistakes-in-react/README.md
@@ -5,3 +5,6 @@ description: Learn about some of the most common mistakes in React
 insights:
   - dont-mutate-state
   - value-types-and-the-initial-state
+  - setstate-is-async
+  - current-state-and-next-state
+  - dependency-array-for-useeffect

--- a/javascript/react/common-mistakes-in-react/README.md
+++ b/javascript/react/common-mistakes-in-react/README.md
@@ -1,0 +1,7 @@
+name: Common mistakes in React
+
+description: Learn about some of the most common mistakes in React
+
+insights:
+  - dont-mutate-state
+  - value-types-and-the-initial-state

--- a/javascript/react/common-mistakes-in-react/current-state-and-next-state.md
+++ b/javascript/react/common-mistakes-in-react/current-state-and-next-state.md
@@ -18,17 +18,18 @@ category: tip
 ---
 ## Content
 
-In the previous insight we have discussed how the `setState()` update call is asynchronous. For this reason, when you update the state to a value that is based on the old state you might end up with weird values if you do the following:
+In the previous insight we have discussed how the `setState()` update call can sometimes be asynchronous. For this reason, the value of `this.state` might not always hold the most up to date value:
 
 ```js
 increaseAge = age => {
   this.setState({
-    age: this.state.age + 1
+    // this.state.age might be stale
+    age: this.state.age + 1 
   });
 };
 ```
 
-This code relies on the current value of state to update it, but it is not correct. The proper way of updating the state is by using the functional form of `setState`:
+This code generates new state based on its current value, which might contain old data. To reliably update the state based on its latest value you should use the functional form of `setState`:
 
 ```js
 increaseAge = () => {
@@ -38,7 +39,9 @@ increaseAge = () => {
 };
 ```
 
-This way, the latest state value is used. When using the functional form of `setState`, you can also pass a second argument - `props` at the time the update is applied. This argument can be used in a manner similar to state.
+This way, the latest state value is **always** provided as an argument to the function you pass into `setState`, and the new state value will become whatever you return from said function. 
+
+Note: the function also receives the latest `props`, as its second argument.
 
 If using functional components, the same logic applies to the `useState` hook:
 
@@ -51,7 +54,7 @@ const increaseAge = () => {
 ---
 ## Practice
 
-Which function would correctly update the state?
+Which function would **always** update the state to the expected value?
 
 ```js
 A = count => {

--- a/javascript/react/common-mistakes-in-react/current-state-and-next-state.md
+++ b/javascript/react/common-mistakes-in-react/current-state-and-next-state.md
@@ -1,0 +1,102 @@
+---
+author: kapnobatai136
+  
+aspects:
+
+  - workout
+
+  - deep
+
+type: normal
+
+category: tip
+
+---
+
+# Current state and next state
+
+---
+## Content
+
+In the previous insight we have discussed how the `setState()` update call is asynchronous. For this reason, when you update the state to a value that is based on the old state you might end up with weird values if you do the following:
+
+```js
+increaseAge = age => {
+  this.setState({
+    age: this.state.age + 1
+  });
+};
+```
+
+This code relies on the current value of state to update it, but it is not correct. The proper way of updating the state is by using the functional form of `setState`:
+
+```js
+increaseAge = () => {
+  this.setState(state => ({
+    age: state.age + 1
+  }));
+};
+```
+
+This way, the latest state value is used. When using the functional form of `setState`, you can also pass a second argument - `props` at the time the update is applied. This argument can be used in a manner similar to state.
+
+If using functional components, the same logic applies to the `useState` hook:
+
+```js
+const increaseAge = () => {
+  setAge(age => age + 1);
+};
+```
+
+---
+## Practice
+
+Which function would correctly update the state?
+
+```js
+A = count => {
+  this.setState({
+    count: this.state.count + 1
+  });
+};
+
+B = () => {
+  this.setState(state => ({
+    count: state.count + 1
+  }));
+};
+
+C = count => {
+  this.setState(state => {
+    count: state.count + 1;
+  });
+};
+```
+
+???
+
+* B
+* A
+* C
+
+---
+## Revision
+
+Complete the following code:
+
+```js
+function Person() {
+  const [age, setAge] = ???(0);
+
+  const increaseAge = () => {
+    ???(??? => age + 1);
+  };
+}
+```
+
+* `useState`
+* `setAge`
+* `age`
+* `setState`
+* `updateAge`
+* `useProps`

--- a/javascript/react/common-mistakes-in-react/dependency-array-for-useeffect.md
+++ b/javascript/react/common-mistakes-in-react/dependency-array-for-useeffect.md
@@ -58,7 +58,19 @@ Note that this is not an issue when using strings, primitive values or numbers a
 
 There are multiple options of dealing with this issue. The first consists of moving the dependency array outside of the component, although in some cases this might not be possible.
 
-The second option is wrapping our value in a `useMemo()` hook which caches[1] our reference during re-renders:
+```js
+// now we aren't re-creating the array
+// on each render
+const features = ["feature1", "feature2"];
+
+function App() {
+  useEffect(() => {
+    // callback
+  }, [features]);
+}
+```
+
+The second option is wrapping our value in a `useMemo()` hook which caches[2] our reference during re-renders:
 
 ```js
 function App() {
@@ -85,3 +97,34 @@ Why would you use a dependency array in your `useEffect()` hook call?
 * To increase the number of re-renders.
 * To save the `state` value at a certain point in time.
 * To have access to multiple versions of the `state`.
+
+---
+## Footnotes
+
+[1: Object.is]
+Sometimes it is really difficult to find out if two values are actually the same value. When thinking of JavaScript, two objects are considered to have the same value if they have the same reference. This can be done through the `Object.is()` function, which is not the same as using the `==` operator (this applies coercion to both sides), or using the `===` operator (this treats `-0` and `+0` as being the same, also treats `Number.NaN` is not equal to `NaN`). Let's take a look at some examples:
+
+```js
+Object.is('foo', 'foo'); // true
+Object.is('foo', 'bar'); // false
+Object.is([], []); // false
+
+var foo = { a: 1 };
+var bar = { a: 1 };
+Object.is(foo, foo); // true
+Object.is(foo, bar); // false
+```
+
+[2: Caching]
+In computer science, memoization refers to a technique used to store the results of an expensive function call and returning the cached result when the same inputs are used. In React, this can be achieved through the `useMemo()` function. To have a better understanding, let's take a look at an example:
+
+```js
+const cachedValue = useMemo(
+  () => expensiveFunction(a, b),
+  [a, b]
+);
+```
+
+You pass a function (`expensiveFunction(a, b)`) and a dependency array (`[a, b]`) in an async manner (`() => ...`). The result is cached, and the function is only re-computed if one of the dependencies changed.
+
+Note that `expensivefunction(a, b)` is ran during rendering.

--- a/javascript/react/common-mistakes-in-react/dependency-array-for-useeffect.md
+++ b/javascript/react/common-mistakes-in-react/dependency-array-for-useeffect.md
@@ -21,7 +21,7 @@ links:
 ---
 ## Content
 
-One important feature of the `useEffect()` hook is represented by its dependency array. When included, the dependency array can result in a performance increase due to reducing the number of re-renders. Let's take a look at an example:
+One important feature of the `useEffect()` hook is represented by its dependency array. When included, the `useEffect` hook only runs when one or more of its dependencies change, which can result in a performance increase by reducing the number of re-renders. Let's take a look at an example:
 
 ```js
 function App() {
@@ -32,7 +32,7 @@ function App() {
 }
 ```
 
-Now, React checks if the current value of name is different from the previous value of name, and only re-renders if that is true.
+Now, React will only re-runs the hook function if the current value of `name` is different from its previous value.
 
 Let's take a look at another example:
 
@@ -46,13 +46,19 @@ function App() {
 }
 ```
 
-In this case, React only stores a reference to the `features` array and compares it to the previous reference of the array. We have define the `features` array inside our component, meaning that after every render we recreate the array. When React compares the two references, it will always result on running the callback function. This is because we recreate the `features` array on every render which results in recreating the reference that leads to said array.
+It's important to understand that React uses a similar comparison mechanism[1] to `===` when determining if the value of a hook dependency changed.
+
+In the case of objects and object-like structures such as arrays, `===` will compare the references of two objects, not the data they contain.
+
+Even if we pass `[1, 2, 3]` to `useEffect` twice, the actual values within the array will not matter, React will only be interested if the array itself (i.e. the reference to it) is the same, not its content.
+
+In the example above we are creating the `features` array within the component `App`. This means that anytime `App` renders, `features` will contain a new array instance with the same contents. When React checks if `features` array is the same as before, it never will be because we're recreating it on each render, which means that the `useEffect` hook will also run on each render.
 
 Note that this is not an issue when using strings, primitive values or numbers as these are compared by value rather than reference.
 
 There are multiple options of dealing with this issue. The first consists of moving the dependency array outside of the component, although in some cases this might not be possible.
 
-The second option is wrapping our value in a `useMemo()` hook which keeps our reference during re-renders:
+The second option is wrapping our value in a `useMemo()` hook which caches[1] our reference during re-renders:
 
 ```js
 function App() {
@@ -67,7 +73,7 @@ function App() {
 }
 ```
 
-The third and last option consists of using a deep compare hook that properly tracks the dependency references. We will not cover this option in this insight, but make sure to check out the resources for a link to a popular custom hook.
+The third and last option consists of using a deep compare hook that tracks the dependency references and their contents. We will not cover this option in this insight, but make sure to check out the resources for a link to a popular custom hook that handles this use-case.
 ---
 ## Practice
 

--- a/javascript/react/common-mistakes-in-react/dependency-array-for-useeffect.md
+++ b/javascript/react/common-mistakes-in-react/dependency-array-for-useeffect.md
@@ -1,0 +1,81 @@
+---
+author: kapnobatai136
+  
+aspects:
+
+  - workout
+
+  - deep
+
+type: normal
+
+category: tip
+
+links:
+  - '[use-deep-compare-effect](https://github.com/kentcdodds/use-deep-compare-effect){website}'
+
+---
+
+# Dependency array for useEffect
+
+---
+## Content
+
+One important feature of the `useEffect()` hook is represented by its dependency array. When included, the dependency array can result in a performance increase due to reducing the number of re-renders. Let's take a look at an example:
+
+```js
+function App() {
+  const [name, setName] = useState("");
+  useEffect(() => {
+    document.title = `Welcome to ${name}!`;
+  }, [name]);
+}
+```
+
+Now, React checks if the current value of name is different from the previous value of name, and only re-renders if that is true.
+
+Let's take a look at another example:
+
+```js
+function App() {
+  const features = ["feature1", "feature2"];
+
+  useEffect(() => {
+    // callback
+  }, [features]);
+}
+```
+
+In this case, React only stores a reference to the `features` array and compares it to the previous reference of the array. We have define the `features` array inside our component, meaning that after every render we recreate the array. When React compares the two references, it will always result on running the callback function. This is because we recreate the `features` array on every render which results in recreating the reference that leads to said array.
+
+Note that this is not an issue when using strings, primitive values or numbers as these are compared by value rather than reference.
+
+There are multiple options of dealing with this issue. The first consists of moving the dependency array outside of the component, although in some cases this might not be possible.
+
+The second option is wrapping our value in a `useMemo()` hook which keeps our reference during re-renders:
+
+```js
+function App() {
+  const features = useMemo(
+    () => ["features1", "features2"],
+    []
+  );
+
+  useEffect(() => {
+    // callback
+  }, [features]);
+}
+```
+
+The third and last option consists of using a deep compare hook that properly tracks the dependency references. We will not cover this option in this insight, but make sure to check out the resources for a link to a popular custom hook.
+---
+## Practice
+
+Why would you use a dependency array in your `useEffect()` hook call?
+
+???
+
+* To reduce the number of re-renders.
+* To increase the number of re-renders.
+* To save the `state` value at a certain point in time.
+* To have access to multiple versions of the `state`.

--- a/javascript/react/common-mistakes-in-react/dont-mutate-state.md
+++ b/javascript/react/common-mistakes-in-react/dont-mutate-state.md
@@ -17,8 +17,6 @@ type: normal
 
 category: tip
 
-links:
-
 ---
 
 # Don't mutate state

--- a/javascript/react/common-mistakes-in-react/dont-mutate-state.md
+++ b/javascript/react/common-mistakes-in-react/dont-mutate-state.md
@@ -24,7 +24,7 @@ category: tip
 ---
 ## Content
 
-Now that you know how to handle yourself with React, it is time to learn about some of the most common mistakes and how to avoid them.
+Now that you know how to start using React, it is time to learn about some of the most common mistakes and how to avoid them.
 
 One of the most common mistakes one can make when using React is trying to directly modify the `state`. In a previous workout we have discussed how the `state` is considered immutable, and some methods of updating arrays or objects were presented. Consider the following example:
 
@@ -36,7 +36,7 @@ const updateFeaturesList = (e, idx) => {
 };
 ```
 
-Although this code might seem correct at a first glance, the UI won't reflect this because the `state` is updated with the same object reference which doesn't trigger a re-render. Because the `state` has an asynchronous nature, mutating it might result in later `state` updates overriding the changes you have made directly. When using functional components, use the setter method returned by `useState()`:
+Although this code might seem correct at a first glance, the UI won't actually reflect this change because the `state` is updated on the same object reference, which doesn't trigger a re-render. Because the `state` updates can happen asynchronously (React might do this outside of our control), mutating it might result in later `state` updates overriding the changes you have made directly. To circumvent this when using functional components, use the setter method returned by `useState()`:
 
 ```js
 const updateFeaturesList = (e, idx) => {
@@ -54,7 +54,7 @@ const updateFeaturesList = (e, idx) => {
 };
 ```
 
-Note that by using the `.map()` array prototype and object spread we are ensuring that the original `state` items are not changed.
+Note that by using the `.map()` array method (which creates a new array) and object spread (which creates a new object) we are ensuring that the original `state` items are not changed.
 
 ---
 ## Practice

--- a/javascript/react/common-mistakes-in-react/dont-mutate-state.md
+++ b/javascript/react/common-mistakes-in-react/dont-mutate-state.md
@@ -1,0 +1,83 @@
+---
+author: kapnobatai136
+
+levels:
+
+  - basic
+  
+  - medium
+  
+aspects:
+
+  - workout
+
+  - deep
+
+type: normal
+
+category: how to
+
+links:
+
+---
+
+# Don't mutate state
+
+---
+## Content
+
+Now that you know how to handle yourself with React, it is time to learn about some of the most common mistakes and how to avoid them.
+
+One of the most common mistakes one can make when using React is trying to directly modify the `state`. In a previous workout we have discussed how the `state` is considered immutable, and some methods of updating arrays or objects were presented. Consider the following example:
+
+```js
+const updateFeaturesList = (e, idx) => {
+  listFeatures[idx].checked =
+    e.target.checked;
+  setListFeatures(listFeatures);
+};
+```
+
+Although this code might seem correct at a first glance, the UI won't reflect this because the `state` is updated with the same object reference which doesn't trigger a re-render. Because the `state` has an asynchronous nature, mutating it might result in later `state` updates overriding the changes you have made directly. When using functional components, use the setter method returned by `useState()`:
+
+```js
+const updateFeaturesList = (e, idx) => {
+  const { checked } = e.target;
+  setListFeatures(features => {
+    return features.map(
+      (feature, index) => {
+        if (idx === index) {
+          feature = { ...feature, checked };
+        }
+        return feature;
+      }
+    );
+  });
+};
+```
+
+Note that by using the `.map()` array prototype and object spread we are ensuring that the original `state` items are not changed.
+
+---
+## Practice
+
+Which of the following represents a good reason to mutate `state`?
+
+???
+
+* you should never mutate state
+* to write less code
+* to increase your app's performance
+* to have easier access to nested values
+
+---
+## Revision
+
+Which of the following represents a good reason to mutate `state`?
+
+???
+
+* you should never mutate state
+* to write less code
+* to increase your app's performance
+* to have easier access to nested values

--- a/javascript/react/common-mistakes-in-react/dont-mutate-state.md
+++ b/javascript/react/common-mistakes-in-react/dont-mutate-state.md
@@ -15,7 +15,7 @@ aspects:
 
 type: normal
 
-category: how to
+category: tip
 
 links:
 

--- a/javascript/react/common-mistakes-in-react/setstate-is-async.md
+++ b/javascript/react/common-mistakes-in-react/setstate-is-async.md
@@ -18,7 +18,7 @@ category: tip
 ---
 ## Content
 
-More often than not, we are very eager with accessing a new state value after setting it. Because a new value is set on the next available render, the state might not reflect your latest update. Let's take a look at an example:
+More often than not, we are eager with accessing a new state value after setting it. Because a new value is set on the next available render, the state might not reflect your latest update. Let's take a look at an example:
 
 ```js
 handleChange = age => {
@@ -27,7 +27,7 @@ handleChange = age => {
 };
 ```
 
-In the `handleChange` function, when we call `this.props.callback(this.state.count)` we are getting the old state value, not the new one we set through `this.setState({ count })`. This issue can be fixed by using an optional second argument of the `setState` method, a callback function that is called after the state is updated:
+In the `handleChange` function, when we call `this.props.callback(this.state.count)` we are getting the old state value, not the new one we set through `this.setState({ count })` (because the state hasn't yet updated between the two lines of code). This issue can be fixed by using an optional second argument of the `setState` method, a callback function that is called after the state is updated:
 
 ```js
 handleChange = age => {
@@ -51,7 +51,9 @@ const handleChange = value => {
 };
 ```
 
-In the `useEffect()` hook, the `callback(age)` is called whenever the value of `age` changes. One important takeaway here is that `setState` is async, but not in a way that returns a promise. Using `async`, `await` or `then` methods will not work.
+In the `useEffect()` hook, the `callback(age)` is called whenever the value of `age` changes. 
+
+Note: Another important takeaway here is that although `setState` can be async, this happens behind the scenes, and we cannot control it. `setState` doesn't return a promise so using `await` or `then` will not work.
 
 ---
 ## Practice

--- a/javascript/react/common-mistakes-in-react/setstate-is-async.md
+++ b/javascript/react/common-mistakes-in-react/setstate-is-async.md
@@ -1,0 +1,102 @@
+---
+author: kapnobatai136
+  
+aspects:
+
+  - workout
+
+  - deep
+
+type: normal
+
+category: tip
+
+links:
+
+---
+
+# setState is async
+
+---
+## Content
+
+More often than not, we are very eager with accessing a new state value after setting it. Because a new value is set on the next available render, the state might not reflect your latest update. Let's take a look at an example:
+
+```js
+handleChange = age => {
+  this.setState({ age });
+  this.props.callback(this.state.age);
+};
+```
+
+In the `handleChange` function, when we call `this.props.callback(this.state.count)` we are getting the old state value, not the new one we set through `this.setState({ count })`. This issue can be fixed by using an optional second argument of the `setState` method, a callback function that is called after the state is updated:
+
+```js
+handleChange = age => {
+  this.setState({ age }, () => {
+    this.props.callback(this.state.age);
+  });
+};
+```
+
+If using functional components together with hooks, you would use:
+
+```jsx
+const [age, setAge] = useState(0);
+
+useEffect(() => {
+  callback(age);
+}, [age, callback]);
+
+const handleChange = value => {
+  setAge(value);
+};
+```
+
+In the `useEffect()` hook, the `callback(age)` is called whenever the value of `age` changes. One important takeaway here is that `setState` is async, but not in a way that returns a promise. Using `async`, `await` or `then` methods will not work.
+
+---
+## Practice
+
+When thinking of class components, where would you insert a callback function so that you can access the latest value of the state?
+
+???
+
+* in the `setState` method
+* after the `setState` method
+* before the `setState` method
+* anywhere, as long as it is in the same scope as the `setState` method
+
+---
+## Revision
+
+Complete the following code to correctly update the state:
+
+```js
+// class
+handleChange = age => {
+  this.setState({ age }, () => {
+    ???(???);
+  });
+};
+
+// function
+const [age, setAge] = useState(0);
+
+useEffect(() => {
+  ???;
+}, ???);
+
+const handleChange = value => {
+  setAge(value);
+};
+```
+
+* `this.props.callback`
+* `this.state.age`
+* `callback(age)`
+* `[age, callback]`
+* `props.callback`
+* `state.age`
+* `[callback, age]`
+* `callback(state.age)`

--- a/javascript/react/common-mistakes-in-react/setstate-is-async.md
+++ b/javascript/react/common-mistakes-in-react/setstate-is-async.md
@@ -11,8 +11,6 @@ type: normal
 
 category: tip
 
-links:
-
 ---
 
 # setState is async

--- a/javascript/react/common-mistakes-in-react/value-types-and-the-initial-state.md
+++ b/javascript/react/common-mistakes-in-react/value-types-and-the-initial-state.md
@@ -1,0 +1,86 @@
+---
+author: kapnobatai136
+
+levels:
+
+  - basic
+  
+  - medium
+  
+aspects:
+
+  - workout
+
+  - deep
+
+type: normal
+
+category: how to
+
+links:
+
+---
+
+# Value types and the initial state
+
+---
+## Content
+
+Let's start this insight by taking a look at an example:
+
+```jsx
+function Enki() {
+  const [user, setUser] = useState(null)
+
+  getProfile = () => {
+    fetch('/api/profile').then(data => {
+      setUser(data);
+    });
+  }
+
+  return(
+    <div>
+      <p>User name:</p>
+      <p>{user.name}</p>
+    </div>
+  );
+}
+```
+
+---
+## Practice
+
+This question will be shown with the insight, and users will have just read the content.
+It's best to use a code example here.
+
+example:
+Given this directory structure, change directories **from** `www/css` **to** `www/images/promo`:
+```
+- www
+  - css
+  - images
+    - promo
+  - js
+
+```
+
+`cd ???/???/???`
+
+* ..
+* images
+* promo
+* www
+* js
+* .
+* ^
+
+---
+## Revision
+
+Revision questions are shown without the insight, and users may never have seen the content. Use a code example or multiple choice question.
+
+???
+
+* right answer
+* wrong answer
+* wrong answer 2

--- a/javascript/react/common-mistakes-in-react/value-types-and-the-initial-state.md
+++ b/javascript/react/common-mistakes-in-react/value-types-and-the-initial-state.md
@@ -17,8 +17,6 @@ type: normal
 
 category: tip
 
-links:
-
 ---
 
 # Value types and the initial state
@@ -85,7 +83,3 @@ What value should you use when defining the initial state?
 * Any value.
 * `{}`
 * `[]`
-
----
-## Revision
-

--- a/javascript/react/common-mistakes-in-react/value-types-and-the-initial-state.md
+++ b/javascript/react/common-mistakes-in-react/value-types-and-the-initial-state.md
@@ -15,7 +15,7 @@ aspects:
 
 type: normal
 
-category: how to
+category: tip
 
 links:
 
@@ -29,19 +29,43 @@ links:
 Let's start this insight by taking a look at an example:
 
 ```jsx
-function Enki() {
-  const [user, setUser] = useState(null)
+function Person() {
+  const [info, setInfo] = useState(null);
 
-  getProfile = () => {
-    fetch('/api/profile').then(data => {
-      setUser(data);
+  getInfo = () => {
+    fetch("/api/profile").then(data => {
+      setInfo(data);
     });
-  }
+  };
 
-  return(
+  return (
     <div>
-      <p>User name:</p>
-      <p>{user.name}</p>
+      <p>Name: {info.name}</p>
+      <p>Age: {info.age}</p>
+    </div>
+  );
+}
+```
+
+Normally, you would expect this function to work without a problem. This is a common mistake because while the data is being fetched though the `getProfile()` call, the component is rendered with the initial state. In our case, the initial state is `null` which leads to a rendering error. Not providing an initial state for nested objects, or defining an empty array as initial state and then trying to access the n-th element would lead to the same error. For these reasons, it is important to define the initial state as close to the updated state as possible. In our case, we should've wrote:
+
+```jsx
+function Person() {
+  const [info, setInfo] = useState({
+    name: "",
+    age: 0
+  });
+
+  getInfo = () => {
+    fetch("/api/profile").then(data => {
+      setInfo(data);
+    });
+  };
+
+  return (
+    <div>
+      <p>Name: {info.name}</p>
+      <p>Age: {info.age}</p>
     </div>
   );
 }
@@ -50,37 +74,18 @@ function Enki() {
 ---
 ## Practice
 
-This question will be shown with the insight, and users will have just read the content.
-It's best to use a code example here.
+What value should you use when defining the initial state?
 
-example:
-Given this directory structure, change directories **from** `www/css` **to** `www/images/promo`:
-```
-- www
-  - css
-  - images
-    - promo
-  - js
+???
 
-```
-
-`cd ???/???/???`
-
-* ..
-* images
-* promo
-* www
-* js
-* .
-* ^
+* A value that is as close to the updated state as possible.
+* `null`
+* `""`
+* `undefined`
+* Any value.
+* `{}`
+* `[]`
 
 ---
 ## Revision
 
-Revision questions are shown without the insight, and users may never have seen the content. Use a code example or multiple choice question.
-
-???
-
-* right answer
-* wrong answer
-* wrong answer 2


### PR DESCRIPTION
Writing a new workout for React in which I will present the most common mistakes:

1. Don't mutate state
- why you shouldn't mutate state
- example of what happens when trying to mutate state
- example of how to avoid mutating state

2. Value types and the initial state
- what happens when the initial state isn't properly defined
- example of error that results from setting initial state to `null`
- example of defining initial state as close to the updated value as possible

3. setState is async
- example of accessing a new state value after setting it and result
- how to properly access the new state value
- class and function component example

4. Current state and next state
- example of the wrong way of setting state based on value of previous state
- explained why it was the wrong way
- how to properly reference the previous state
- example for class and function component

5. Dependency array for `useEffect`
- explained what a dependency array does and why it is important to include it
- explained what happens when the dependency array is defined inside the component
- provided three methods for overcoming the issue of recreating the reference