### PR TITLE
Improve string-raw.md

### DIFF
--- a/javascript/ecmascript-2015/string-flexibility/string-raw.md
+++ b/javascript/ecmascript-2015/string-flexibility/string-raw.md
@@ -63,7 +63,7 @@ Fill in the gaps such that the `log` statement makes sense:
 ```javascript
 console.log(
   String.???`A\nB???
-)
+);
 // A\nB
 ```
 

--- a/javascript/ecmascript-2015/string-flexibility/string-raw.md
+++ b/javascript/ecmascript-2015/string-flexibility/string-raw.md
@@ -24,14 +24,10 @@ links:
 ---
 ## Content
 
-`String.raw` is used to work with template strings and is best explained with an example:
-
-In JavaScript `\n` is used to indicate a new line.
-
-Consider if we had the following template literal:
+`String.raw` is used to work with template strings and is best explained with an example. Knowing that in JavaScript, `\n` is used to indicate a new line, let's take a look at the following piece of code:
 
 ```javascript
-`Line1\nLine2!`;
+console.log(`Line1\nLine2!`);
 ```
 
 When executed, the code above would treat `\n` as a new line and produce:
@@ -41,13 +37,24 @@ When executed, the code above would treat `\n` as a new line and produce:
 Line2"
 ```
 
-However sometimes it is desirable to work with a string template in its raw format (without interpretation of escaped characters) - `String.raw` allows you to do this - note how there is no new line between Line1 and Line2 now, just `\n`:
+However sometimes it is desirable to work with a string template in its raw format (without interpretation of escaped characters). `String.raw` allows you to do this - note how there is no new line between Line1 and Line2 now, just `\n`:
 
 ```javascript
-String.raw`Line1\nLine2`;
+console.log(String.raw`Line1\nLine2`);
 // "Line1\nLine2"
 ```
 
+Normally, `String.raw` is not called as a function, but for the sake of the argument let's call it as a function:
+```js
+String.raw({raw: 'enki'}, 0, 1, 2);
+// e0n1k2i
+```
+
+The above code is the equivalent of calling:
+
+```js
+String.raw`e${0}n${1}k${2}i`
+```
 ---
 ## Practice
 

--- a/javascript/ecmascript-2015/string-flexibility/string-raw.md
+++ b/javascript/ecmascript-2015/string-flexibility/string-raw.md
@@ -44,7 +44,7 @@ console.log(String.raw`Line1\nLine2`);
 // "Line1\nLine2"
 ```
 
-Normally, `String.raw` is not called as a function, but for the sake of the argument let's call it as a function:
+Alternatively, we can invoke `String.raw` like a regular function, which would look something like this:
 ```js
 String.raw({raw: 'enki'}, 0, 1, 2);
 // e0n1k2i
@@ -55,6 +55,9 @@ The above code is the equivalent of calling:
 ```js
 String.raw`e${0}n${1}k${2}i`
 ```
+
+Note that although calling `String.raw` as a function is possible, it is not done often.
+
 ---
 ## Practice
 


### PR DESCRIPTION
A user commented that the `String.raw` should be called using parentheses as usual. I added an explanation of why that is not the case.