### PR TITLE
Linux - Keep useful commands in your shell history with tags

### DIFF
--- a/linux/user-and-file-management/terminal-history/keep-useful-commands-in-your-shell-history-with-tags.md
+++ b/linux/user-and-file-management/terminal-history/keep-useful-commands-in-your-shell-history-with-tags.md
@@ -32,7 +32,6 @@ links:
 aspects:
   - workout
 
-
 ---
 
 # Keep useful commands in your shell history with tags
@@ -41,21 +40,28 @@ aspects:
 ## Content
 
 Tag commands for future reference:
-```
-$ some_command -some_flag
-       some_path # useful
+```bash
+$ some_command
+   -some_flag some_path #useful
 ```
 
 Then it is possible to search your bash history using `Ctrl+R`:
 
-```text
-(reverse-i-search)`#useful': 
-  some_command -some_flag some_path #useful 
+```shell
+$ some_command 
+    -some_flag some_path #useful
+bck-i-search: useful
 ```
 
-Because `# useful` is just a comment in bash you are not limited to this word. Therefore, creative use of tags can save you time. 
+Although `#useful` is just a comment in bash, you are not limited to this word. You can also just search for commands that you've used recently. Therefore, creative use of tags can save you time.
 
-Command history is saved in *~/.bash_history* file, which is emptied after a history limit is reached. In order to preserve the tag collection, a backup of the file is needed.
+```shell
+$ some_command
+    -some_flag some_path #useful
+bck-i-search: some_command
+```
+
+Command history is saved in *~/.bash_history* file. When its limit is reached, commands at the beginning of the file are removed to make room for new commands. The default limit is 500 commands, but you can modify the `HISTFILESIZE` (maximum number of files contained in the history file) and the `HISTSIZE` (number of commands to remember in the command history) variables to change this limit. You can find these variables either in your `~/.profile` or `~/.bash_profile` file[1].
 
 ---
 ## Revision
@@ -63,8 +69,12 @@ Command history is saved in *~/.bash_history* file, which is emptied after a his
 To reverse search for a tagged command you have to press ???.
 
 
-* ctrl+r
-* ctrl+h
-* ctrl+c
+* `Ctrl+R`
+* `Ctrl+H`
+* `Ctrl+C`
 
- 
+---
+## Footnotes
+
+[1:Command History]
+Check out [this thread](https://unix.stackexchange.com/a/163406) to find out how you can further customize your shell or how `HISTFILESIZE` and `HISTSIZE` work under the hood.


### PR DESCRIPTION
As a user reported, the `~/.bash_history` file is not emptied when its limit is reached, but rather commands from the beginning of the file are removed to make room. Also added a footnote that leads the users to a link with more information.