### PR TITLE
Link to You don't know JS repo broken

### DIFF
--- a/javascript/core/intro-js/console-in-javascript.md
+++ b/javascript/core/intro-js/console-in-javascript.md
@@ -23,7 +23,7 @@ tags:
 
 links:
 
-  - '[github.com](https://github.com/getify/You-Dont-Know-JS/blob/master/async%20&%20performance/ch1.md){website}'
+  - '[github.com](https://github.com/getify/You-Dont-Know-JS/blob/2nd-ed/sync-async/ch1.md){website}'
   - '[developer.mozilla.org](https://developer.mozilla.org/en/docs/Web/API/Console/log){website}'
 
 


### PR DESCRIPTION
The Link is pointing to non existing code, since they are working on the second edition, the repo structure changed