### PR TITLE
change getElementsByTagName parameter to a string

### DIFF
--- a/javascript/browser-apis/intro-browser-js/modify-elements.md
+++ b/javascript/browser-apis/intro-browser-js/modify-elements.md
@@ -112,7 +112,7 @@ for (
 ```
 
 * `getElementsByTagName`
-* `p`
+* `"p"`
 * `paragraphTags`
 * `innerHTML`
 * `document`


### PR DESCRIPTION
In the quiz the method's argument is missing `"..."` so it seems that `p` is not a string