### PR TITLE
Python - Dictionary Standard Mapping Types

### DIFF
--- a/python/core/fundamental-data-structures/dictionary-standard-mapping-type.md
+++ b/python/core/fundamental-data-structures/dictionary-standard-mapping-type.md
@@ -21,7 +21,7 @@ standards:
 
 links:
 
-  - '[docs.python.org](https://docs.python.org/3.5/library/stdtypes.html#mapping-types-dict){website}'
+  - '[Mapping Types](https://docs.python.org/3.5/library/stdtypes.html#mapping-types-dict){website}'
 
 
 ---
@@ -35,16 +35,15 @@ The **dictionary** (dict) is Python's main mapping type. It maps **hashable** va
 
 They behave similar to *lists*, being easily grown or shrunk by adding or removing elements. The two important differences are that items stored in **dictionaries** can only be accessed using their key, and each key can only point to a single value. We call this **key integrity**. The Python dictionary's correspondent in Java is the *HashMap*; in C they are called *hash tables*, and in JavaScript, they are called *objects*.
 
-
 There are several ways to create a *dictionary*:
 - using the `{key: value}` syntax
 - with the `dict` constructor
 - with both the above syntax and constructor together
 
 ```python
-d1 = {'first':1, 'second':2}
-d2 = dict(first=1, second=2)
-d3 = dict({'first':1, 'second':2})
+d1 = {"first": 1, "second": 2}
+d2 = dict(first = 1, second = 2)
+d3 = dict({"first": 1, "second": 2})
 ```
 
 This is how we access elements:
@@ -52,17 +51,16 @@ This is how we access elements:
 print(d1['first'])
 # 1
 print(d2)
-# {'second': 2, 'first': 1}
+# {"second": 2, "first": 1}
 ```
-
 
 One interesting feature *dictionaries* have is the `update()` method. It behaves similarly to a concatenation of two lists, but with a few differences. Basically, it merges the keys and values from one dictionary into another and overwrites values of the same key:
 ```python
 prefs = {"fruit": "apple", "car": "Tesla"}
-prefs2 = {"fruit": "pear","animal": "dog"}
+prefs2 = {"fruit": "pear", "animal": "dog"}
 prefs.update(prefs2)
 print(prefs)
-# {'car': 'Tesla', 'fruit': 'pear',
+# {"car": "Tesla", "fruit": "pear",
 # "animal": "dog"}
 ```
 
@@ -83,9 +81,6 @@ animals = {"cat": "persian", "dog": "pug"}
 * ["dog"]
 * ["cat"]
 * ("dog")
-
-
-
 
 ---
 ## Revision


### PR DESCRIPTION
Changed all quotation marks to be of the same type (`"`).