### PR TITLE
Fix typo in branches-in-git.md

### DIFF
--- a/git/essentials/fundamentals/branches-in-git.md
+++ b/git/essentials/fundamentals/branches-in-git.md
@@ -70,7 +70,7 @@ To rename the current branch:
 $ git branch -m new-branch-name
 
 ```
-Thinking of a branch as a pointer to a specific state of the repository, we can visualize how changing to a different branch takes us to a different stage of the same project. Different changes of the same project are stored on different branches. To change the branch, we are on we can use `git checkout`[4]:
+Thinking of a branch as a pointer to a specific state of the repository, we can visualize how changing to a different branch takes us to a different stage of the same project. Different changes of the same project are stored on different branches. To change the branch we are on, we can use `git checkout`[4]:
 ```
 $ git checkout my-branch
 ```


### PR DESCRIPTION
Changed comma placement to make the sentence easier to read.