### PR TITLE
Python - The `zip` Built-in Function

### DIFF
--- a/python/functional-programming/arrays-i/the-zip-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-zip-built-in-function.md
@@ -60,7 +60,7 @@ print(zip(a, b, c))
 # ('a5', 'b5', 'c5')]
 ```
 
-The star operator `*` can be used with `zip` to do the opposite action&mdash;to unzip a list. This action takes an iterator of tuples and returns a list for each field in the tuples.[2] Unzipping has the syntax:
+The star operator `*` can be used with `zip` to do the opposite action&mdash;to unzip a list. This action takes an iterator of tuples and returns a tuple for each field in the tuples[2]. Unzipping has the syntax:
 
 ```python
 zip(*zippedList)

--- a/python/functional-programming/arrays-i/the-zip-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-zip-built-in-function.md
@@ -80,10 +80,18 @@ print(x)
 print(y)
 print(z)
 
-#result:
+# result:
 # x = ('a1', 'a2', 'a3', 'a4', 'a5')
 # y = ('b1', 'b2', 'b3', 'b4', 'b5')
 # z = ('c1', 'c2', 'c3', 'c4', 'c5')
+```
+
+Note that when unzipping, Python returns **tuples** instead of **lists**:
+
+```py
+type(x)
+# result:
+# <type 'tuple'>
 ```
 
 ---


### PR DESCRIPTION
- user mention that it is unclear whether the `zip(*foo)` methods returns lists or tuples (it returns tuples)
- added a paragraph to clear this confusion