### PR TITLE
Python - The from...import statement

### DIFF
--- a/python/core/intro-to-modules/the-from-import-statement.md
+++ b/python/core/intro-to-modules/the-from-import-statement.md
@@ -2,21 +2,17 @@
 author: SebaRaba
 
 levels:
-
   - beginner
 
 type: normal
 
 category: must-know
+
 aspects:
   - introduction
   - workout
-standards:
-  python.modules.0: 10
-  python.modules.1: 10
 
 links:
-
   - '[from...import in depth](https://www.tutorialspoint.com/python3/python_modules.htm){website}'
 
 
@@ -49,7 +45,7 @@ To access exposed methods of it we could do the following:
 ```python
 import my_functions
 
-print(my_functions.cube(3)) # 27
+my_functions.cube(3) # 27
 my_functions.hello('Seba') # Hello, Seba
 ```
 


### PR DESCRIPTION
- example was calling `print(cube(3))`, but the `cube` method was already calling `print`
- fixed by removing the `print` statement

```
# my_functions.py

def hello(what):
    text = "Hello, " + what
    print(text)
def cube(x):
    print(x ** 3)
def quad(x):
    print(x ** 4)
```