### PR TITLE
Java - Why use `volatile` `long` or `double`

### DIFF
--- a/java/threading/multithreading/why-use-volatile-long-or-double.md
+++ b/java/threading/multithreading/why-use-volatile-long-or-double.md
@@ -57,4 +57,8 @@ In order to avoid this problem, `long` and `double` values need to be granted at
 private volatile long i = 0;
 ```
 
-Making the field `volatile` will guarantee its atomicity.
+We've previously said that making the field `volatile` **will not guarantee its atomicity**. This is true, especially in the case of operations that require more than one read or write.
+
+Making a variable `volatile` will guarantee that **each individual read or write operation** on the variable will be atomic.
+
+If you have more than one read or write operation (e.g. `i = i + 1`), this **will not be atomic**.

--- a/java/threading/multithreading/why-use-volatile-long-or-double.md
+++ b/java/threading/multithreading/why-use-volatile-long-or-double.md
@@ -33,7 +33,7 @@ notes: >-
 ---
 ## Content
 
-When multi threading read/writes operations with 64 bit values, you need to take into consideration that `long` and `double` values are not atomic. That means that a single write or read is treated as two separate operations: one to each `32 bit` half.
+When multi threading read/writes operations with 64 bit values, you need to take into consideration that `long` and `double` values are not atomic[1]. That means that a single write or read is treated as two separate operations: one to each `32 bit` half.
 
 ```java
 class SampleLong { 
@@ -58,3 +58,9 @@ private volatile long i = 0;
 ```
 
 Making a variable `volatile` will guarantee that **each individual read or write operation** on the variable will be atomic. If you have more than one read or write operation (e.g. `i = i + 1`), this **will not be atomic**. This does not only apply to `long` and `double` variables, but also to all other types.
+
+---
+## Footnotes
+
+[1:Atomic]
+In programming, an operation (or a set of operations) is considered atomic if it appears to the rest of the system as a single, indivisible step.

--- a/java/threading/multithreading/why-use-volatile-long-or-double.md
+++ b/java/threading/multithreading/why-use-volatile-long-or-double.md
@@ -37,7 +37,7 @@ When multi threading read/writes operations with 64 bit values, you need to take
 
 ```java
 class SampleLong { 
-  private long i = 0; //OR double  
+  private long i = 0; // OR double  
   void assignValue(long j) {
     i = j;
   }
@@ -51,14 +51,10 @@ Bearing that in mind, this can result in a situation when a thread sees the form
 
 Imagine a scenario when a thread repeatedly calls the `assignValue` method and another one the `printLong` method. The last one can occasionally print a value of `i` that is neither `0` nor the value of `j` argument.
 
-In order to avoid this problem, `long` and `double` values need to be granted atomicity.
+We've previously said that making the field `volatile` **will not guarantee its atomicity**. This is true, especially in the case of operations that require more than one read or write (like with `long` or `double` variables).
 
 ```java
 private volatile long i = 0;
 ```
 
-We've previously said that making the field `volatile` **will not guarantee its atomicity**. This is true, especially in the case of operations that require more than one read or write.
-
-Making a variable `volatile` will guarantee that **each individual read or write operation** on the variable will be atomic.
-
-If you have more than one read or write operation (e.g. `i = i + 1`), this **will not be atomic**.
+Making a variable `volatile` will guarantee that **each individual read or write operation** on the variable will be atomic. If you have more than one read or write operation (e.g. `i = i + 1`), this **will not be atomic**. This does not only apply to `long` and `double` variables, but also to all other types.


### PR DESCRIPTION
- used [this source](https://stackoverflow.com/a/19744523) as reference

TODOs before merging:
- [ ] resolve comments in the app