### PR TITLE
Update select-structure.md

### DIFF
--- a/sql/dql/using-select/select-structure.md
+++ b/sql/dql/using-select/select-structure.md
@@ -52,7 +52,7 @@ select *
 from pokemon;
 ```
 
-They keywords are usually capitalized simply to make the code easier to read. 
+The keywords are usually capitalized simply to make the code easier to read. 
 
 ---
 ## Practice


### PR DESCRIPTION
Corrected the sentence

"They keywords are usually capitalized simply to make the code easier to read." 

To


"The keywords are usually capitalized simply to make the code easier to read."