### PR TITLE
Fixed typo in Typescript lesson

### DIFF
--- a/typescript/introduction/tsc-classes-and-interfaces/tsc-interfaces-intro.md
+++ b/typescript/introduction/tsc-classes-and-interfaces/tsc-interfaces-intro.md
@@ -71,7 +71,7 @@ payment.value = 0;
 ---
 ## Practice
 
-Fill in the blacks such that `reader` satisfies the `BookReader` interface:
+Fill in the blanks such that `reader` satisfies the `BookReader` interface:
 
 ```ts
 interface Book {


### PR DESCRIPTION
The lesson on classes and interfaces had a typo.