### PR TITLE
Add a link to the iptables manpage

### DIFF
--- a/linux/networking-and-security/firewall-configuration-maintenance/intro-to-iptables.md
+++ b/linux/networking-and-security/firewall-configuration-maintenance/intro-to-iptables.md
@@ -1,5 +1,5 @@
 ---
-author: tuwi.dc
+author: tuwidc
 
 levels:
 

--- a/linux/networking-and-security/firewall-configuration-maintenance/intro-to-iptables.md
+++ b/linux/networking-and-security/firewall-configuration-maintenance/intro-to-iptables.md
@@ -21,8 +21,9 @@ tags:
   - security
 
   - netfilter
-
-
+ 
+links:
+  - '[iptables(8) - Linux man page](https://linux.die.net/man/8/iptables){website}' 
 
 notes: ''
 


### PR DESCRIPTION
I recently reviewed this lesson which is good but concise. It would benefit from having a link to the manpage.