### PR TITLE
React - Immutability Helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Types of change:
 - [Linux - Common Environment Variables - Explain what PWD stands for](https://github.com/enkidevs/curriculum/pull/2161)
 
 ### Fixed
-- [React - Immutability helpers in React - Fix footnote display](https://github.com/enkidevs/curriculum/pull/2163)
+- [React - Immutability helpers in React - Fix footnote display & remove test footnote](https://github.com/enkidevs/curriculum/pull/2163)
 - [Python - List Methods II - Fixed typo when using the #insert method ](https://github.com/enkidevs/curriculum/pull/2156)
 
 ## June 3rd 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Types of change:
 - [Linux - Common Environment Variables - Explain what PWD stands for](https://github.com/enkidevs/curriculum/pull/2161)
 
 ### Fixed
+- [React - Immutability helpers in React - Fix footnote display](https://github.com/enkidevs/curriculum/pull/2163)
 - [Python - List Methods II - Fixed typo when using the #insert method ](https://github.com/enkidevs/curriculum/pull/2156)
 
 ## June 3rd 2020

--- a/react/tips/good-to-know/react-immutability-helpers-in-react.md
+++ b/react/tips/good-to-know/react-immutability-helpers-in-react.md
@@ -53,7 +53,7 @@ const newData = update(myData, {
 
 Although this format might need some getting used to, it provides a much better approach for determining which data has changed[1].
 
-In terms of `notation[2]`, keys that are preceded by a `$` are called **commands** (`{ $push: array }`, `{ $apply: function }`, etc.) and the data that is being mutated is called the **target**. 
+In terms of notation, keys that are preceded by a `$` are called **commands** (`{ $push: array }`, `{ $apply: function }`, etc.) and the data that is being mutated is called the **target**. 
 
 Here is how you would perform a shallow merge using the `update()` method:
 

--- a/react/tips/good-to-know/react-immutability-helpers-in-react.md
+++ b/react/tips/good-to-know/react-immutability-helpers-in-react.md
@@ -1,21 +1,11 @@
 ---
 author: catalin
 
-levels:
-
-  - basic
-
-  - advanced
-
-  - medium
-
 type: normal
 
 category: feature
 
-
 links:
-
   - '[Immutability Helper](https://github.com/kolodny/immutability-helper){website}'
 
 parent: custom-proptype-s-to-be-required
@@ -56,12 +46,12 @@ import update from "immutability-helper";
 const newData = update(myData, {
   x: { y: { z: { $set: 10 } } },
   // myData.x.y.z = 10;
-  a: { b: { $push: [13 ] } }
+  a: { b: { $push: [13] } }
   // myData.a.b.push(13);
 });
 ```
 
-Although this format might need some getting used to, it provides a much better approach for determining which data has changed [1].
+Although this format might need some getting used to, it provides a much better approach for determining which data has changed[1].
 
 In terms of notation, keys that are preceded by a `$` are called **commands** (`{ $push: array }`, `{ $apply: function }`, etc.) and the data that is being mutated is called the **target**. 
 


### PR DESCRIPTION
- fix array index display (previously we couldn't use `[13]` because our footnote rule failed, but we discovered it was only a backend issue; they display correctly in the app)