### PR TITLE
SQL - Handling Blobs in SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Types of change:
 ## June 8th 2020
 
 ### Fixed
+- [SQL - Handling Blobs in SQL - Fix blob sizes & general formatting](https://github.com/enkidevs/curriculum/pull/2167)
 - [Regex - Ranges I - Fix slashes](https://github.com/enkidevs/curriculum/pull/2165)
 - [Regex - Ranges II - Fix slashes](https://github.com/enkidevs/curriculum/pull/2165)
 

--- a/sql/ddl/storing-blobs/storing-blobs-in-mysql.md
+++ b/sql/ddl/storing-blobs/storing-blobs-in-mysql.md
@@ -1,32 +1,19 @@
 ---
 author: mihaiberq
 
-levels:
-
-  - beginner
-
-  - basic
-
 type: normal
 
 category: how to
 
-standards:
-  sql.choose-sql-datatype.2: 10
-  
 tags:
-
   - introduction
-
   - workout
-
   - deep
 
 aspects:
   - introduction
   - workout
   - deep
-
 
 ---
 
@@ -36,23 +23,28 @@ aspects:
 ## Content
 
 There are four *BLOB* types in MySQL:
-- `tinyblob`: 1 + 2^8 bytes (0.256 MB)
-- `blob`: 2 + 2^16 bytes (65 MB)
+- `tinyblob`: 1 + 2^8 bytes (0.256 KB)
+- `blob`: 2 + 2^16 bytes (65.5 KB)
 - `mediumblob`: 3 + 2^24 bytes (16.7 MB)
 - `longblob`: 4 + 2^32 bytes (4.2 GB)
 
 In MySQL, `blob` is similar to `varbinary(n)` and can be used interchangeably. To create the table:
+
 ```sql
 CREATE TABLE sprite(
   id serial PRIMARY KEY,
   pokemon longblob
 );
 ```
+
 And to insert values:
+
 ```sql
 INSERT INTO sprite
 VALUES(LOAD_FILE('pikachu.png'));
+
 -- or
+
 INSERT INTO sprite
 VALUES('0xBYTESOFPIKACHUSPRITE');
 ```
@@ -61,6 +53,7 @@ VALUES('0xBYTESOFPIKACHUSPRITE');
 ## Practice
 
 In a MySQL database, store a BLOB by loading the contents of a file:
+
 ```sql
 ??? ??? sprite(image)
 VALUES(???(???));
@@ -78,6 +71,7 @@ VALUES(???(???));
 ## Revision
 
 In a MySQL database, store a BLOB as a binary string:
+
 ```sql
 ??? ??? sprite(image)
 VALUES(???);
@@ -88,6 +82,3 @@ VALUES(???);
 * `'0xTHISISMYIMAGE'`
 * `0xTHISISMYIMAGE`
 * `LOAD_FILE('pikachu.jpg')`
-
- 
- 


### PR DESCRIPTION
- fix blob sizes and formatting
- `tinyblob` and `blob` had their sizes as `MB` when they actually were `KB` 