### PR TITLE
Add sudo to chattr

### DIFF
--- a/linux/user-and-file-management/default-permissions/making-a-file-unalterable-with-chattr.md
+++ b/linux/user-and-file-management/default-permissions/making-a-file-unalterable-with-chattr.md
@@ -1,5 +1,5 @@
 ---
-author: tuwi.dc
+author: tuwidc
 
 levels:
 

--- a/linux/user-and-file-management/default-permissions/making-a-file-unalterable-with-chattr.md
+++ b/linux/user-and-file-management/default-permissions/making-a-file-unalterable-with-chattr.md
@@ -42,18 +42,18 @@ tags:
 
 You can make a file unalterable so that it cannot be changed or deleted even by root:
 ```
-$ chattr +i /path/to/file
+$ sudo chattr +i /path/to/file
 ```
 
 After that the file becomes *untouchable*.
 
 To update the file, remove the attribute using `-i` flag:
 ```
-$ chattr -i /path/to/file
+$ sudo chattr -i /path/to/file
 ```
 Use `-R` flag to unlock a directory.
 ```
-$ chattr -R -i directory/
+$ sudo chattr -R -i directory/
 ```
 
 The Mac equivalent is:
@@ -67,9 +67,9 @@ $ chflags nouchg /path/to/file
 ---
 ## Revision
 
-Make `enki`  *file* untouchable:
+Make `enki` *file* untouchable:
 ```
-$ ??? ??? enki
+$ sudo ??? ??? enki
 ```
 
 * `chattr`


### PR DESCRIPTION
As suggested by another user in the comments the `chattr` needs to be run as root.
```
ubuntu@ip-172-31-57-119:~$ chattr +i file.txt
chattr: Operation not permitted while setting flags on file.txt
```
I tested this on a Mac and sudo is not required for `chflags`