### PR TITLE
Place arguments in correct order

### DIFF
--- a/linux/user-and-file-management/user-management-utilities/random-password-generator.md
+++ b/linux/user-and-file-management/user-management-utilities/random-password-generator.md
@@ -1,7 +1,10 @@
 ---
 author: tuwidc
+
 type: normal
+
 category: hack
+
 tags:
   - linux
   - terminal
@@ -9,12 +12,14 @@ tags:
   - password
   - generator
   - workout
+
 links:
   - '[Base64 Encoding](https://en.wikipedia.org/wiki/Base64){website}'
+  - '[openssl rand manpage](https://www.openssl.org/docs/man1.0.2/man1/rand.html){documentation}'
+
 ---
 
 # Random password generator
-
 
 ---
 
@@ -29,7 +34,10 @@ openssl rand -base64 32
 WkY+q7Z5YmiHTrpV0lwtSApbepky1BNWc1s1E7lFcpY=
 ```
 
-The `rand 32` option tells `openssl` to generate a random sequence of 32 bytes and `-base64` tells `openssl` to base64-encode the output (see the link at the end for details).
+Here's what happens in this command:
+- `rand` tells `openssl` to generate a random sequence
+- `-base64` tells `openssl` to base64-encode the output (check the *Learn More* section for more details)
+- `32` tells `openssl` that the random sequence should have 32 bytes
 
 Using `pwgen`:
 
@@ -46,7 +54,6 @@ By using the `-y` option we can tell `pwgen` to also include symbols in the pass
 pwgen -s -y 40
 i^^iAa5o^oc["+43[G]{62&S!&Mt:L]ny7qbR~g0
 ```
-
 
 ---
 

--- a/linux/user-and-file-management/user-management-utilities/random-password-generator.md
+++ b/linux/user-and-file-management/user-management-utilities/random-password-generator.md
@@ -25,7 +25,7 @@ You can generate passwords in the terminal in many ways. Two of them are listed 
 Using `openssl`:
 
 ```shell
-openssl rand 32 -base64
+openssl rand -base64 32
 WkY+q7Z5YmiHTrpV0lwtSApbepky1BNWc1s1E7lFcpY=
 ```
 


### PR DESCRIPTION
The arguments for `openssl rand` example were not in the correct order.