### PR TITLE
Applying correct syntax to the example

### DIFF
--- a/docker/fundamentals/images/docker-images.md
+++ b/docker/fundamentals/images/docker-images.md
@@ -52,7 +52,7 @@ We can use the `docker history <IMAGE_ID>` command to show the layers of changes
 For example:
 
 ```bash
-docker history nginx
+docker history 3f8a4339aadd
 ```
 
 would output something like:


### PR DESCRIPTION
To avoid any confusion I've updated the `docker history` command to use the image ID from the blow example.