### PR TITLE
Fix a typo in the practical example

### DIFF
--- a/linux/jobs-and-processes-data-manipulation/file-streams/selecting-portions-of-a-line-using-cut.md
+++ b/linux/jobs-and-processes-data-manipulation/file-streams/selecting-portions-of-a-line-using-cut.md
@@ -59,7 +59,7 @@ user2:/home/user2
 ... etc. etc. ...
 ```
 
-The fields in `/etc/passwd` are `:`-delimited with the first field containing the username and the second field containing the user's home directory.
+The fields in `/etc/passwd` are `:`-delimited with the first field containing the username and the sixth field containing the user's home directory.
 
 
 ---


### PR DESCRIPTION
Fixed a typo stating the second field of /etc/passwd contained the user's home directory when it is the sixth.