### PR TITLE
Update always-specify-type-parameter.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Types of change:
 
 ### Fixed
 - [Javascript - Closures - Add missing parentheses in the third sentence](https://github.com/enkidevs/curriculum/pull/2462)
+- [Java - Always Specify Type Parameter - Update code block identifier](https://github.com/enkidevs/curriculum/pull/2463)
 
 ## November 30th 2020
 

--- a/java/fundamentals/tips-ii/always-specify-type-parameter.md
+++ b/java/fundamentals/tips-ii/always-specify-type-parameter.md
@@ -19,14 +19,14 @@ links:
 
 A *parameterized type* would look like:
 
-```plain-text
+```java
 List<String> oceans = Arrays.asList(
    "Pacific", "Atlantic", "Indian");
 ```
 
 Whereas, a *raw type* would look like:
 
-```plain-text
+```java
 List oceans = Arrays.asList(
    "Pacific", "Atlantic", "Indian");
 ```


### PR DESCRIPTION
change `plain-text` code identifiers to `java` because the code blocks represent code and not the output.