### PR TITLE
Replace broken link with a valid one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## December 2nd 2020
+
+### Fixed
+- [Security - The Heap Data Structure - Replace broken link with a valid one](https://github.com/enkidevs/curriculum/pull/2464)
+
 ## December 1st 2020
 
 ### Fixed

--- a/comp-sci/data-structures-and-algorithms/heap-and-trie/the-heap-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/heap-and-trie/the-heap-data-structure.md
@@ -3,14 +3,14 @@ author: jfarmer
 type: normal
 category: must-know
 links:
-  - >-
-    [The heap data
-    structure](https://www.geeksforgeeks.org/heap-data-structure/){website}
+  - '[The heap data structure](https://www.geeksforgeeks.org/heap-data-structure/){website}'
+  - '[Binary Heap](https://www.cs.cmu.edu/~rdriley/121/notes/heaps.html#3-binary-heap){website}'
+  
 parent: balanced-vs-unbalanced-binary-trees
+
 ---
 
 # The Heap Data Structure
-
 
 ---
 

--- a/comp-sci/data-structures-and-algorithms/heap-and-trie/the-heap-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/heap-and-trie/the-heap-data-structure.md
@@ -5,7 +5,7 @@ category: must-know
 links:
   - >-
     [The heap data
-    structure](https://www.cs.cmu.edu/~adamchik/15-121/lectures/Binary%20Heaps/heaps.html){website}
+    structure](https://www.geeksforgeeks.org/heap-data-structure/){website}
 parent: balanced-vs-unbalanced-binary-trees
 ---
 


### PR DESCRIPTION
Replace the broken link with a valid one I found on Geeks for geeks