### PR TITLE
deprecate `parent` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+### December 7th 2020
+
+### Changed
+- [Deprecate the `parent` field from both workouts and insights](https://github.com/enkidevs/curriculum/pull/2473)
+
 ## December 3rd 2020
 
 ### Added

--- a/comp-sci/data-structures-and-algorithms/algorithms-i/approximating-memory-and-time-required-by-data-types.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-i/approximating-memory-and-time-required-by-data-types.md
@@ -9,7 +9,7 @@ links:
   - >-
     [The Big-O
     Notation](https://rob-bell.net/2009/06/a-beginners-guide-to-big-o-notation/){website}
-parent: node-height-and-depth
+
 ---
 
 # Approximating Memory and Time Required by Data Types

--- a/comp-sci/data-structures-and-algorithms/algorithms-i/approximation-methods.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-i/approximation-methods.md
@@ -6,7 +6,7 @@ links:
   - >-
     [Big O vs Big
     Theta](http://stackoverflow.com/questions/471199/what-is-the-difference-between-%CE%98n-and-on){website}
-parent: approximating-memory-and-time-required-by-data-types
+
 ---
 
 # Approximation Methods

--- a/comp-sci/data-structures-and-algorithms/algorithms-i/binary-search.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-i/binary-search.md
@@ -4,7 +4,7 @@ type: normal
 category: must-know
 links:
   - '[Binary Search](http://quiz.geeksforgeeks.org/binary-search/){website}'
-parent: approximation-methods
+
 ---
 
 # Binary Search

--- a/comp-sci/data-structures-and-algorithms/algorithms-i/primality-test.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-i/primality-test.md
@@ -2,7 +2,7 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: sieve-of-eratosthenes
+
 ---
 
 # Primality Test

--- a/comp-sci/data-structures-and-algorithms/algorithms-i/sieve-of-eratosthenes.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-i/sieve-of-eratosthenes.md
@@ -6,7 +6,7 @@ links:
   - >-
     [Sieve of
     Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes){website}
-parent: binary-search
+
 ---
 
 # Sieve of Eratosthenes

--- a/comp-sci/data-structures-and-algorithms/algorithms-ii/binary-expression-tree.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-ii/binary-expression-tree.md
@@ -2,7 +2,7 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: parsing-reverse-polish-notation
+
 ---
 
 # Binary Expression Tree

--- a/comp-sci/data-structures-and-algorithms/algorithms-ii/exponentiation-by-squaring.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-ii/exponentiation-by-squaring.md
@@ -6,7 +6,7 @@ links:
   - >-
     [Exponentiation by
     squaring](https://en.wikipedia.org/wiki/Exponentiation_by_squaring){website}
-parent: binary-expression-tree
+
 ---
 
 # Exponentiation By Squaring

--- a/comp-sci/data-structures-and-algorithms/algorithms-ii/levenshtein-distance.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-ii/levenshtein-distance.md
@@ -6,7 +6,7 @@ links:
   - >-
     [Optimizing Levensthein distance
     computation](http://stackoverflow.com/questions/3183149/most-efficient-way-to-calculate-levenshtein-distance){website}
-parent: exponentiation-by-squaring
+
 ---
 
 # Levenshtein Distance

--- a/comp-sci/data-structures-and-algorithms/algorithms-ii/parsing-reverse-polish-notation.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-ii/parsing-reverse-polish-notation.md
@@ -2,7 +2,7 @@
 author: mihaiberq
 type: normal
 category: how to
-parent: reverse-polish-notation
+
 ---
 
 # Parsing Reverse Polish Notation

--- a/comp-sci/data-structures-and-algorithms/algorithms-ii/reverse-polish-notation.md
+++ b/comp-sci/data-structures-and-algorithms/algorithms-ii/reverse-polish-notation.md
@@ -6,7 +6,7 @@ links:
   - >-
     [Prefix, Infix and Postfix
     notations](http://www.cs.man.ac.uk/~pjj/cs2121/fix.html){website}
-parent: trie-data-structure
+
 ---
 
 # Reverse Polish Notation

--- a/comp-sci/data-structures-and-algorithms/binary-search-tree/balanced-vs-unbalanced-binary-trees.md
+++ b/comp-sci/data-structures-and-algorithms/binary-search-tree/balanced-vs-unbalanced-binary-trees.md
@@ -6,7 +6,7 @@ links:
   - >-
     [Why Is It Safer to Keep the Tree
     Balanced?](http://stackoverflow.com/questions/8015630/definition-of-a-balanced-tree){website}
-parent: removing-keys-from-a-binary-search-tree
+
 ---
 
 # Balanced vs. Unbalanced Binary Trees

--- a/comp-sci/data-structures-and-algorithms/binary-search-tree/inserting-data-into-a-binary-search-tree.md
+++ b/comp-sci/data-structures-and-algorithms/binary-search-tree/inserting-data-into-a-binary-search-tree.md
@@ -5,8 +5,6 @@ type: normal
 
 category: must-know
 
-parent: verifying-a-binary-search-tree
-
 ---
 
 # Inserting Data Into a Binary Search Tree

--- a/comp-sci/data-structures-and-algorithms/binary-search-tree/oh-that-was-the-answer.md
+++ b/comp-sci/data-structures-and-algorithms/binary-search-tree/oh-that-was-the-answer.md
@@ -2,7 +2,7 @@
 author: mihaiberq
 type: tetris
 category: must-know
-parent: primality-test
+
 ---
 
 # Big-Oh, that was the answer!

--- a/comp-sci/data-structures-and-algorithms/binary-search-tree/removing-keys-from-a-binary-search-tree.md
+++ b/comp-sci/data-structures-and-algorithms/binary-search-tree/removing-keys-from-a-binary-search-tree.md
@@ -2,7 +2,6 @@
 author: jfarmer
 type: normal
 category: how to
-parent: inserting-data-into-a-binary-search-tree
 ---
 
 # Removing Keys From a Binary Search Tree

--- a/comp-sci/data-structures-and-algorithms/binary-search-tree/the-binary-search-tree-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/binary-search-tree/the-binary-search-tree-data-structure.md
@@ -4,7 +4,6 @@ type: normal
 category: must-know
 links:
   - '[Binary Search Trees](http://algs4.cs.princeton.edu/32bst/){website}'
-parent: post-order-traversal
 ---
 
 # The Binary Search Tree Data Structure

--- a/comp-sci/data-structures-and-algorithms/binary-search-tree/verifying-a-binary-search-tree.md
+++ b/comp-sci/data-structures-and-algorithms/binary-search-tree/verifying-a-binary-search-tree.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Validating a
     BST](http://stackoverflow.com/questions/499995/how-do-you-validate-a-binary-search-tree){website}
-parent: the-binary-search-tree-data-structure
 ---
 
 # Verifying A Binary Search Tree

--- a/comp-sci/data-structures-and-algorithms/graph-algorithms/bellman-ford-algorithm.md
+++ b/comp-sci/data-structures-and-algorithms/graph-algorithms/bellman-ford-algorithm.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Step-by-step, interactive Bellman-Ford algorithm
     application](https://www-m9.ma.tum.de/graph-algorithms/spp-bellman-ford/index_en.html){website}
-parent: dijkstras-iteration
 ---
 
 # Bellman-Ford Algorithm

--- a/comp-sci/data-structures-and-algorithms/graph-algorithms/bellman-ford-iteration.md
+++ b/comp-sci/data-structures-and-algorithms/graph-algorithms/bellman-ford-iteration.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: bellman-ford-algorithm
 ---
 
 # Bellman-Ford Algorithm Iteration

--- a/comp-sci/data-structures-and-algorithms/graph-algorithms/dijkstras-algorithm.md
+++ b/comp-sci/data-structures-and-algorithms/graph-algorithms/dijkstras-algorithm.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Step-by-step, interactive Dijkstra`s algorithm
     application](https://www-m9.ma.tum.de/graph-algorithms/spp-dijkstra/index_en.html){website}
-parent: levenshtein-distance
 ---
 
 # Dijkstra's Algorithm

--- a/comp-sci/data-structures-and-algorithms/graph-algorithms/dijkstras-iteration.md
+++ b/comp-sci/data-structures-and-algorithms/graph-algorithms/dijkstras-iteration.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: dijkstras-algorithm
 ---
 
 # Dijkstra's Algorithm Iteration

--- a/comp-sci/data-structures-and-algorithms/graph-algorithms/traveling-salesman-problem.md
+++ b/comp-sci/data-structures-and-algorithms/graph-algorithms/traveling-salesman-problem.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Shortcuts for
     TSP](https://www.wired.com/2013/01/traveling-salesman-problem/){website}
-parent: bellman-ford-iteration
 ---
 
 # Traveling Salesman Problem

--- a/comp-sci/data-structures-and-algorithms/heap-and-trie/inserting-data-into-a-heap-with-the-upheap-operation.md
+++ b/comp-sci/data-structures-and-algorithms/heap-and-trie/inserting-data-into-a-heap-with-the-upheap-operation.md
@@ -2,7 +2,6 @@
 author: jfarmer
 type: normal
 category: how to
-parent: the-heap-data-structure
 ---
 
 # Inserting Data Into a Heap With The `upheap` Operation

--- a/comp-sci/data-structures-and-algorithms/heap-and-trie/o-logn-operations-for-heaps.md
+++ b/comp-sci/data-structures-and-algorithms/heap-and-trie/o-logn-operations-for-heaps.md
@@ -2,7 +2,6 @@
 author: jfarmer
 type: normal
 category: must-know
-parent: removing-data-from-a-heap-with-the-downheap-operation
 ---
 
 # How Do Binary Heaps Enable O(log(n)) Insertion and Removal?

--- a/comp-sci/data-structures-and-algorithms/heap-and-trie/removing-data-from-a-heap-with-the-downheap-operation.md
+++ b/comp-sci/data-structures-and-algorithms/heap-and-trie/removing-data-from-a-heap-with-the-downheap-operation.md
@@ -2,7 +2,6 @@
 author: jfarmer
 type: normal
 category: how to
-parent: inserting-data-into-a-heap-with-the-upheap-operation
 ---
 
 # Removing Data From a Heap With The `downheap` Operation

--- a/comp-sci/data-structures-and-algorithms/heap-and-trie/the-heap-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/heap-and-trie/the-heap-data-structure.md
@@ -5,8 +5,6 @@ category: must-know
 links:
   - '[The heap data structure](https://www.geeksforgeeks.org/heap-data-structure/){website}'
   - '[Binary Heap](https://www.cs.cmu.edu/~rdriley/121/notes/heaps.html#3-binary-heap){website}'
-  
-parent: balanced-vs-unbalanced-binary-trees
 
 ---
 

--- a/comp-sci/data-structures-and-algorithms/heap-and-trie/trie-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/heap-and-trie/trie-data-structure.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Working With
     Tries](https://medium.com/algorithms/trie-prefix-tree-algorithm-ee7ab3fe3413){website}
-parent: o-logn-operations-for-heaps
 ---
 
 # The Trie Data Structure

--- a/comp-sci/data-structures-and-algorithms/intro-data-structures/the-array-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/intro-data-structures/the-array-data-structure.md
@@ -10,7 +10,6 @@ links:
     [What Is an
     Array?](http://www.bbc.co.uk/education/guides/z4tf9j6/revision/2){website}
 
-parent: what-is-a-data-structure
 ---
 
 # The Array Data Structure

--- a/comp-sci/data-structures-and-algorithms/intro-data-structures/the-linked-list-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/intro-data-structures/the-linked-list-data-structure.md
@@ -11,8 +11,6 @@ links:
   - >-
     [Linked List Basics](http://cslibrary.stanford.edu/103/LinkedListBasics.pdf){website}
 
-parent: the-array-data-structure
-
 ---
 
 # The Linked List Data Structure

--- a/comp-sci/data-structures-and-algorithms/intro-data-structures/the-queue-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/intro-data-structures/the-queue-data-structure.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: the-stack-data-structure
 ---
 
 # The Queue Data Structure

--- a/comp-sci/data-structures-and-algorithms/intro-data-structures/the-stack-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/intro-data-structures/the-stack-data-structure.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Stacks and
     Queues](https://en.wikibooks.org/wiki/Data_Structures/Stacks_and_Queues){website}
-parent: the-linked-list-data-structure
 ---
 
 # The Stack Data Structure

--- a/comp-sci/data-structures-and-algorithms/intro-graphs/graph-adt.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/graph-adt.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Graph
     Representation](http://www.geeksforgeeks.org/graph-and-its-representations/){website}
-parent: the-components-of-a-graph
 ---
 
 # Graph Representation and ADT

--- a/comp-sci/data-structures-and-algorithms/intro-graphs/node-height-and-depth.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/node-height-and-depth.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: the-tree-data-structure
 ---
 
 # Node Height and Depth

--- a/comp-sci/data-structures-and-algorithms/intro-graphs/the-components-of-a-graph-ii.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/the-components-of-a-graph-ii.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: the-graph-data-structure
 ---
 
 # More Components of a Graph

--- a/comp-sci/data-structures-and-algorithms/intro-graphs/the-components-of-a-graph.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/the-components-of-a-graph.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: the-graph-data-structure
 ---
 
 # The Components of a Graph

--- a/comp-sci/data-structures-and-algorithms/intro-graphs/the-graph-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/the-graph-data-structure.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - '[Graph Theory](https://en.wikipedia.org/wiki/Graph_theory){website}'
   - '[Graph Theory Overview](https://www.youtube.com/watch?v=82zlRaRUsaY){video}'
-parent: the-queue-data-structure
 ---
 
 # The Graph Data Structure

--- a/comp-sci/data-structures-and-algorithms/intro-graphs/the-tree-data-structure.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/the-tree-data-structure.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Tree data
     structure](http://www.cs.cmu.edu/~clo/www/CMU/DataStructures/Lessons/lesson4_1.htm){website}
-parent: graph-adt
 ---
 
 # The Tree Data Structure

--- a/comp-sci/data-structures-and-algorithms/intro-graphs/what-should-it-be-stored-in.md
+++ b/comp-sci/data-structures-and-algorithms/intro-graphs/what-should-it-be-stored-in.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: fillTheGap
 category: must-know
-parent: the-queue-data-structure
 ---
 
 # What should it be stored in?

--- a/comp-sci/data-structures-and-algorithms/mst-algorithms/0-1-knapsack-problem.md
+++ b/comp-sci/data-structures-and-algorithms/mst-algorithms/0-1-knapsack-problem.md
@@ -1,15 +1,18 @@
 ---
 author: mihaiberq
+
 type: normal
+
 category: must-know
+
 links:
   - >-
-    [A more in-depth explanation of the
-    problem](https://www.quora.com/Whats-an-intuitive-explanation-for-the-0-1-knapsack-problem-in-data-structures-and-algorithms){website}
+    [A More in-Depth Explanation of the
+    Problem](https://www.quora.com/Whats-an-intuitive-explanation-for-the-0-1-knapsack-problem-in-data-structures-and-algorithms){website}
+
 ---
 
 # (0-1) Knapsack Problem
-
 
 ---
 

--- a/comp-sci/data-structures-and-algorithms/mst-algorithms/0-1-knapsack-problem.md
+++ b/comp-sci/data-structures-and-algorithms/mst-algorithms/0-1-knapsack-problem.md
@@ -6,7 +6,6 @@ links:
   - >-
     [A more in-depth explanation of the
     problem](https://www.quora.com/Whats-an-intuitive-explanation-for-the-0-1-knapsack-problem-in-data-structures-and-algorithms){website}
-parent: prims-iteration
 ---
 
 # (0-1) Knapsack Problem

--- a/comp-sci/data-structures-and-algorithms/mst-algorithms/kruskals-algorithm.md
+++ b/comp-sci/data-structures-and-algorithms/mst-algorithms/kruskals-algorithm.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Step-by-step, interactive Kruskal`s algorithm
     application](https://www-m9.ma.tum.de/graph-algorithms/mst-kruskal/index_en.html){website}
-parent: traveling-salesman-problem
 ---
 
 # Kruskal's Algorithm

--- a/comp-sci/data-structures-and-algorithms/mst-algorithms/kruskals-iteration.md
+++ b/comp-sci/data-structures-and-algorithms/mst-algorithms/kruskals-iteration.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: kruskals-algorithm
 ---
 
 # Kruskal's Algorithm Iteration

--- a/comp-sci/data-structures-and-algorithms/mst-algorithms/prims-algorithm.md
+++ b/comp-sci/data-structures-and-algorithms/mst-algorithms/prims-algorithm.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Step-by-step, interactive Kruskal`s algorithm
     application](https://www-m9.ma.tum.de/graph-algorithms/mst-prim/index_en.html){website}
-parent: kruskals-iteration
 ---
 
 # Prim's Algorithm

--- a/comp-sci/data-structures-and-algorithms/mst-algorithms/prims-iteration.md
+++ b/comp-sci/data-structures-and-algorithms/mst-algorithms/prims-iteration.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: prims-algorithm
 ---
 
 # Prim's Algorithm Iteration

--- a/comp-sci/data-structures-and-algorithms/tree-traversals/depth-first-traversal.md
+++ b/comp-sci/data-structures-and-algorithms/tree-traversals/depth-first-traversal.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: tree-traversals
 ---
 
 # Depth-first Traversal

--- a/comp-sci/data-structures-and-algorithms/tree-traversals/in-order-traversal.md
+++ b/comp-sci/data-structures-and-algorithms/tree-traversals/in-order-traversal.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: pre-order-traversal
 ---
 
 # In-order Traversal

--- a/comp-sci/data-structures-and-algorithms/tree-traversals/post-order-traversal.md
+++ b/comp-sci/data-structures-and-algorithms/tree-traversals/post-order-traversal.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: in-order-traversal
 ---
 
 # Post-order Traversal

--- a/comp-sci/data-structures-and-algorithms/tree-traversals/pre-order-traversal.md
+++ b/comp-sci/data-structures-and-algorithms/tree-traversals/pre-order-traversal.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: depth-first-traversal
 ---
 
 # Pre-order Traversal

--- a/comp-sci/data-structures-and-algorithms/tree-traversals/tree-traversals.md
+++ b/comp-sci/data-structures-and-algorithms/tree-traversals/tree-traversals.md
@@ -4,7 +4,6 @@ type: normal
 category: must-know
 links:
   - '[Tree traversals](https://en.wikipedia.org/wiki/Tree_traversal){website}'
-parent: primality-test
 ---
 
 # Tree Traversals

--- a/comp-sci/networking/fundamentals-i/network-models-tcp-ip.md
+++ b/comp-sci/networking/fundamentals-i/network-models-tcp-ip.md
@@ -7,7 +7,6 @@ links:
     [what-when-how.com](http://what-when-how.com/data-communications-and-networking/network-models-data-communications-and-networking/){website}
   - >-
     [www.webopedia.com](http://www.webopedia.com/quick_ref/OSI_Layers.asp){website}
-parent: types-of-networks
 ---
 
 # Network Models (TCP/IP)

--- a/comp-sci/networking/fundamentals-i/network-models-tcp-ip.md
+++ b/comp-sci/networking/fundamentals-i/network-models-tcp-ip.md
@@ -1,12 +1,16 @@
 ---
 author: SebaRaba
+
 type: normal
+
 category: must-know
+
 links:
   - >-
-    [what-when-how.com](http://what-when-how.com/data-communications-and-networking/network-models-data-communications-and-networking/){website}
+    [Network Models](http://what-when-how.com/data-communications-and-networking/network-models-data-communications-and-networking/){website}
   - >-
-    [www.webopedia.com](http://www.webopedia.com/quick_ref/OSI_Layers.asp){website}
+    [The 7 Layers of the OSI Model](http://www.webopedia.com/quick_ref/OSI_Layers.asp){website}
+
 ---
 
 # Network Models (TCP/IP)

--- a/comp-sci/networking/fundamentals-i/network-models.md
+++ b/comp-sci/networking/fundamentals-i/network-models.md
@@ -7,7 +7,6 @@ links:
     [what-when-how.com](http://what-when-how.com/data-communications-and-networking/network-models-data-communications-and-networking/){website}
   - >-
     [www.webopedia.com](http://www.webopedia.com/quick_ref/OSI_Layers.asp){website}
-parent: types-of-networks
 ---
 
 # Network models

--- a/comp-sci/networking/fundamentals-i/types-of-networks.md
+++ b/comp-sci/networking/fundamentals-i/types-of-networks.md
@@ -7,7 +7,6 @@ links:
     [study.com](http://study.com/academy/lesson/types-of-networks-lan-wan-wlan-man-san-pan-epn-vpn.html){website}
   - >-
     [www.bbc.co.uk](http://www.bbc.co.uk/education/guides/z36nb9q/revision){website}
-parent: what-is-protocol
 ---
 
 # Types of networks

--- a/comp-sci/networking/fundamentals-i/what-is-a-packet.md
+++ b/comp-sci/networking/fundamentals-i/what-is-a-packet.md
@@ -6,7 +6,6 @@ links:
   - >-
     [www.dummies.com](http://www.dummies.com/programming/networking/cisco/cisco-networking-packets/){website}
   - '[whatismyipaddress.com](http://whatismyipaddress.com/tcp-ip){website}'
-parent: what-is-a-computer-network
 ---
 
 # What is a packet?

--- a/comp-sci/networking/fundamentals-i/what-is-protocol.md
+++ b/comp-sci/networking/fundamentals-i/what-is-protocol.md
@@ -9,8 +9,6 @@ links:
   - >-
     [Transmission Control Protocol](https://www.tutorialspoint.com/internet_technologies/internet_protocols.htm){website}
 
-parent: what-is-a-packet
-
 ---
 
 # What Is a Protocol?

--- a/comp-sci/networking/fundamentals-ii/application-layer.md
+++ b/comp-sci/networking/fundamentals-ii/application-layer.md
@@ -7,7 +7,6 @@ links:
     [www.tutorialspoint.com](https://www.tutorialspoint.com/data_communication_computer_network/application_layer_introduction.htm){website}
   - >-
     [kb.ctera.com](https://kb.ctera.com/article/how-to-open-a-telnet-session-on-windows-7-or-windows-8-os-16.html){website}
-parent: what-are-tcp-and-udp
 ---
 
 # Application Layer

--- a/comp-sci/networking/fundamentals-ii/application-layer.md
+++ b/comp-sci/networking/fundamentals-ii/application-layer.md
@@ -1,12 +1,14 @@
 ---
 author: SebaRaba
+
 type: normal
+
 category: must-know
+
 links:
   - >-
-    [www.tutorialspoint.com](https://www.tutorialspoint.com/data_communication_computer_network/application_layer_introduction.htm){website}
-  - >-
-    [kb.ctera.com](https://kb.ctera.com/article/how-to-open-a-telnet-session-on-windows-7-or-windows-8-os-16.html){website}
+    [DCN - Application Layer Introduction](https://www.tutorialspoint.com/data_communication_computer_network/application_layer_introduction.htm){website}
+
 ---
 
 # Application Layer

--- a/comp-sci/networking/fundamentals-ii/extended-terminologies.md
+++ b/comp-sci/networking/fundamentals-ii/extended-terminologies.md
@@ -6,7 +6,6 @@ links:
   - '[blog.ocens.com](http://blog.ocens.com/?p=140){website}'
   - >-
     [www.digitalocean.com](https://www.digitalocean.com/community/tutorials/an-introduction-to-networking-terminology-interfaces-and-protocols){website}
-parent: application-layer
 ---
 
 # Extended terminologies

--- a/comp-sci/networking/fundamentals-ii/what-are-tcp-and-udp.md
+++ b/comp-sci/networking/fundamentals-ii/what-are-tcp-and-udp.md
@@ -6,7 +6,6 @@ links:
   - >-
     [www.bleepingcomputer.com](https://www.bleepingcomputer.com/tutorials/tcp-and-udp-ports-explained/){website}
   - '[www.diffen.com](http://www.diffen.com/difference/TCP_vs_UDP){website}'
-parent: what-is-a-port
 ---
 
 # What are TCP and UDP?

--- a/comp-sci/networking/fundamentals-ii/what-is-a-port.md
+++ b/comp-sci/networking/fundamentals-ii/what-is-a-port.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [www.tutorialspoint.com](https://www.tutorialspoint.com/computer_fundamentals/computer_ports.htm){website}
-parent: what-is-an-ip-address
 ---
 
 # What is a port?

--- a/comp-sci/networking/fundamentals-ii/what-is-an-ip-address.md
+++ b/comp-sci/networking/fundamentals-ii/what-is-an-ip-address.md
@@ -4,7 +4,6 @@ type: normal
 category: must-know
 links:
   - '[www.computerhope.com](http://www.computerhope.com/jargon/i/ip.htm){website}'
-parent: network-models
 ---
 
 # What is an IP address?

--- a/comp-sci/networking/http-status-codes/client-error-status-codes.md
+++ b/comp-sci/networking/http-status-codes/client-error-status-codes.md
@@ -11,7 +11,6 @@ links:
     [www.tutorialspoint.com](https://www.tutorialspoint.com/http/http_status_codes.htm){website}
   - >-
     [www.w3.org](https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html){website}
-parent: redirection-status-codes
 ---
 
 # Client error status codes

--- a/comp-sci/networking/http-status-codes/informational-status-codes.md
+++ b/comp-sci/networking/http-status-codes/informational-status-codes.md
@@ -2,7 +2,6 @@
 author: SebaRaba
 type: normal
 category: must-know
-parent: http-pipelining
 ---
 
 # Informational status codes

--- a/comp-sci/networking/http-status-codes/redirection-status-codes.md
+++ b/comp-sci/networking/http-status-codes/redirection-status-codes.md
@@ -2,7 +2,6 @@
 author: SebaRaba
 type: normal
 category: must-know
-parent: successful-status-codes
 ---
 
 # Redirection status codes

--- a/comp-sci/networking/http-status-codes/server-error-status-codes.md
+++ b/comp-sci/networking/http-status-codes/server-error-status-codes.md
@@ -2,7 +2,6 @@
 author: SebaRaba
 type: normal
 category: must-know
-parent: client-error-status-codes
 ---
 
 # Server error status codes

--- a/comp-sci/networking/http-status-codes/successful-status-codes.md
+++ b/comp-sci/networking/http-status-codes/successful-status-codes.md
@@ -2,7 +2,6 @@
 author: SebaRaba
 type: normal
 category: must-know
-parent: informational-status-codes
 ---
 
 # Successful status codes

--- a/comp-sci/networking/intro-to-http/https.md
+++ b/comp-sci/networking/intro-to-http/https.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [robertheaton.com](http://robertheaton.com/2014/03/27/how-does-https-actually-work/){website}
-parent: verbs-in-http
 ---
 
 # HTTPS

--- a/comp-sci/networking/intro-to-http/verbs-in-http.md
+++ b/comp-sci/networking/intro-to-http/verbs-in-http.md
@@ -7,7 +7,6 @@ links:
     [www.restapitutorial.com](http://www.restapitutorial.com/lessons/httpmethods.html){website}
   - >-
     [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods){website}
-parent: what-are-status-codes
 ---
 
 # Verbs in HTTP

--- a/comp-sci/networking/intro-to-http/what-are-status-codes.md
+++ b/comp-sci/networking/intro-to-http/what-are-status-codes.md
@@ -4,14 +4,12 @@ type: normal
 category: must-know
 links:
   - >-
-    [www.tutorialspoint.com](https://www.tutorialspoint.com/http/http_status_codes.htm){website}
+    [HTTP - Status Codes](https://www.tutorialspoint.com/http/http_status_codes.htm){website}
   - >-
-    [msdn.microsoft.com](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383887){website}
-  - >-
-    [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status){website}
+    [HTTP Response Status Codes](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status){website}
 ---
 
-# What are status codes?
+# What Are Status Codes?
 
 
 ---

--- a/comp-sci/networking/intro-to-http/what-are-status-codes.md
+++ b/comp-sci/networking/intro-to-http/what-are-status-codes.md
@@ -9,7 +9,6 @@ links:
     [msdn.microsoft.com](https://msdn.microsoft.com/en-us/library/windows/desktop/aa383887){website}
   - >-
     [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status){website}
-parent: what-is-an-url
 ---
 
 # What are status codes?

--- a/comp-sci/networking/intro-to-http/what-is-an-url.md
+++ b/comp-sci/networking/intro-to-http/what-is-an-url.md
@@ -7,7 +7,6 @@ links:
     [docs.oracle.com](https://docs.oracle.com/javase/tutorial/networking/urls/definition.html){website}
   - >-
     [www.computerhope.com](http://www.computerhope.com/jargon/u/url.htm){website}
-parent: what-is-http
 ---
 
 # What is an URL?

--- a/comp-sci/networking/intro-to-http/what-is-http.md
+++ b/comp-sci/networking/intro-to-http/what-is-http.md
@@ -6,7 +6,6 @@ links:
   - '[www.tutorialspoint.com](https://www.tutorialspoint.com/http/){website}'
   - '[techterms.com](https://techterms.com/definition/http){website}'
   - '[http2.github.io](https://http2.github.io/){website}'
-parent: test-connectivity
 ---
 
 # What is HTTP

--- a/comp-sci/networking/metrics/differences-between-bandwidth-and-throughput.md
+++ b/comp-sci/networking/metrics/differences-between-bandwidth-and-throughput.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: must-know
-parent: what-is-jitter
 ---
 
 # Differences between bandwidth and throughput

--- a/comp-sci/networking/metrics/important-networking-metrics.md
+++ b/comp-sci/networking/metrics/important-networking-metrics.md
@@ -7,7 +7,6 @@ links:
     [www.techopedia.com](https://www.techopedia.com/definition/8319/metric-networking){website}
   - >-
     [www.informit.com](http://www.informit.com/articles/article.aspx?p=26129&seqNum=7){website}
-parent: extended-terminologies
 ---
 
 # Important networking metrics

--- a/comp-sci/networking/metrics/what-are-latency-and-ping.md
+++ b/comp-sci/networking/metrics/what-are-latency-and-ping.md
@@ -8,7 +8,6 @@ links:
   - >-
     [www.websitepulse.com](https://www.websitepulse.com/blog/what-is-ping-test){website}
   - '[en.wikipedia.org](https://en.wikipedia.org/wiki/Ping_){website}'
-parent: important-networking-metrics
 ---
 
 # What are latency and ping?

--- a/comp-sci/networking/metrics/what-is-jitter.md
+++ b/comp-sci/networking/metrics/what-is-jitter.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [www.cisco.com](http://www.cisco.com/c/en/us/support/docs/voice/voice-quality/18902-jitter-packet-voice.html){website}
-parent: what-is-packet-loss
 ---
 
 # What is jitter?

--- a/comp-sci/networking/metrics/what-is-packet-loss.md
+++ b/comp-sci/networking/metrics/what-is-packet-loss.md
@@ -11,8 +11,6 @@ links:
   - >-
     [Understanding Packet Loss](https://esj.com/articles/2012/12/13/understanding-packet-loss.aspx){website}
 
-parent: what-are-latency-and-ping
-
 ---
 
 # How Does Packet Loss Happen?

--- a/comp-sci/networking/requests-responses/a-request-example.md
+++ b/comp-sci/networking/requests-responses/a-request-example.md
@@ -7,8 +7,9 @@ category: must-know
 
 links:
   - >-
-    [www.quora.com](https://www.quora.com/What-does-an-HTTP-request-looks-like){website}
-  - '[webaim.org](http://webaim.org/blog/user-agent-string-history/){website}'
+    [What is an "HTTP request"?](https://www.quora.com/What-does-an-HTTP-request-looks-like){website}
+  - >-
+    [History of the Browser User-Agent String](http://webaim.org/blog/user-agent-string-history/){website}
 
 ---
 

--- a/comp-sci/networking/requests-responses/a-request-example.md
+++ b/comp-sci/networking/requests-responses/a-request-example.md
@@ -10,8 +10,6 @@ links:
     [www.quora.com](https://www.quora.com/What-does-an-HTTP-request-looks-like){website}
   - '[webaim.org](http://webaim.org/blog/user-agent-string-history/){website}'
 
-parent: http-request
-
 ---
 
 # A Request Example

--- a/comp-sci/networking/requests-responses/a-response-example.md
+++ b/comp-sci/networking/requests-responses/a-response-example.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [www.tutorialspoint.com](https://www.tutorialspoint.com/http/http_responses.htm){website}
-parent: http-response
 ---
 
 # A Response Example

--- a/comp-sci/networking/requests-responses/http-pipelining.md
+++ b/comp-sci/networking/requests-responses/http-pipelining.md
@@ -6,7 +6,6 @@ links:
   - '[en.wikipedia.org](https://en.wikipedia.org/wiki/HTTP_pipelining){website}'
   - >-
     [brianbondy.com](https://brianbondy.com/blog/119/what-you-should-know-about-http-pipelining){website}
-parent: a-response-example
 ---
 
 # HTTP pipelining

--- a/comp-sci/networking/requests-responses/http-request.md
+++ b/comp-sci/networking/requests-responses/http-request.md
@@ -2,7 +2,6 @@
 author: SebaRaba
 type: normal
 category: must-know
-parent: https
 ---
 
 # The HTTP request

--- a/comp-sci/networking/requests-responses/http-response.md
+++ b/comp-sci/networking/requests-responses/http-response.md
@@ -7,7 +7,6 @@ links:
     [www.w3.org](https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.2){website}
   - >-
     [developer.mozilla.org](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status){website}
-parent: a-request-example
 ---
 
 # The HTTP response

--- a/comp-sci/networking/tools/dns-lookup.md
+++ b/comp-sci/networking/tools/dns-lookup.md
@@ -13,8 +13,6 @@ links:
   - >-
     [How Domain Name Servers Work](http://computer.howstuffworks.com/dns.htm){website}
 
-parent: network-statistics-tools
-
 ---
 
 # DNS Lookup

--- a/comp-sci/networking/tools/network-interfaces-tools.md
+++ b/comp-sci/networking/tools/network-interfaces-tools.md
@@ -6,7 +6,6 @@ links:
   - >-
     [www.computerhope.com](http://www.computerhope.com/unix/uifconfi.htm){website}
   - '[en.wikipedia.org](https://en.wikipedia.org/wiki/Network_interface){website}'
-parent: dns-lookup
 ---
 
 # Network Interfaces

--- a/comp-sci/networking/tools/network-statistics-tools.md
+++ b/comp-sci/networking/tools/network-statistics-tools.md
@@ -1,12 +1,14 @@
 ---
 author: catalin
+
 type: normal
+
 category: how to
+
 links:
   - >-
-    [www.c-jump.com](http://www.c-jump.com/CIS24/Slides/Networking/html_utils/netstat.html){website}
-  - >-
-    [www.ibm.com](https://www.ibm.com/support/knowledgecenter/en/SSMN28_4.1.1/com.ibm.rm.doc_4.1.1/frp_r_pdg_netstat_command.html){website}
+    [Netstat Tutorial](http://www.c-jump.com/CIS24/Slides/Networking/html_utils/netstat.html){website}
+
 ---
 
 # Network Statistics

--- a/comp-sci/networking/tools/network-statistics-tools.md
+++ b/comp-sci/networking/tools/network-statistics-tools.md
@@ -7,7 +7,6 @@ links:
     [www.c-jump.com](http://www.c-jump.com/CIS24/Slides/Networking/html_utils/netstat.html){website}
   - >-
     [www.ibm.com](https://www.ibm.com/support/knowledgecenter/en/SSMN28_4.1.1/com.ibm.rm.doc_4.1.1/frp_r_pdg_netstat_command.html){website}
-parent: tools-to-interact-with-networks
 ---
 
 # Network Statistics

--- a/comp-sci/networking/tools/networking-quiz.md
+++ b/comp-sci/networking/tools/networking-quiz.md
@@ -2,7 +2,6 @@
 author: catalin
 type: fillTheGap
 category: must-know
-parent: network-models
 ---
 
 # Networking Fundamentals Quiz

--- a/comp-sci/networking/tools/test-connectivity.md
+++ b/comp-sci/networking/tools/test-connectivity.md
@@ -6,7 +6,6 @@ links:
   - '[shapeshed.com](https://shapeshed.com/unix-traceroute/){website}'
   - >-
     [www.thegeekstuff.com](http://www.thegeekstuff.com/2009/11/ping-tutorial-13-effective-ping-command-examples){website}
-parent: network-interfaces-tools
 ---
 
 # Testing Internet Connectivity

--- a/comp-sci/networking/tools/tools-to-interact-with-networks.md
+++ b/comp-sci/networking/tools/tools-to-interact-with-networks.md
@@ -7,7 +7,6 @@ links:
     [www.tecmint.com](http://www.tecmint.com/linux-network-configuration-and-troubleshooting-commands/){website}
   - >-
     [slackbook.org](http://slackbook.org/html/basic-network-commands.html){website}
-parent: differences-between-bandwidth-and-throughput
 ---
 
 # Tools to interact with Networks

--- a/git/essentials/dummy-workout/finding-a-tag.md
+++ b/git/essentials/dummy-workout/finding-a-tag.md
@@ -1,23 +1,11 @@
 ---
 author: rosielowther
 
-levels:
-  - basic
-  - medium
-
 type: normal
 
 category: must-know
 
-aspects:
-
-  - workout
-  - deep
-
-parent: using-tags-for-version-control
-
 links:
-
   - '[git-scm.com](http://git-scm.com/book/en/v2/Git-Basics-Tagging){website}'
 
 ---

--- a/git/essentials/features-iii/create-a-global-git-commit-hook.md
+++ b/git/essentials/features-iii/create-a-global-git-commit-hook.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Create A Global Git Commit
     Hook](https://coderwall.com/p/jp7d5q/create-a-global-git-commit-hook){website}
-parent: what-is-a-hook
 ---
 
 # Create a global git commit hook

--- a/git/essentials/features-iii/useful-commit-hooks.md
+++ b/git/essentials/features-iii/useful-commit-hooks.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Git Hooks Official
     Documentation](http://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks){website}
-parent: what-is-a-hook
 ---
 
 # Useful commit hooks

--- a/git/essentials/features-iv/pushing-tags-to-a-server.md
+++ b/git/essentials/features-iv/pushing-tags-to-a-server.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Tagging Official
     Documentation](http://git-scm.com/book/en/v2/Git-Basics-Tagging){website}
-parent: using-tags-for-version-control
 ---
 
 # Pushing tags to a server

--- a/git/essentials/remote-repository/git-erminology.md
+++ b/git/essentials/remote-repository/git-erminology.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: fillTheGap
 category: must-know
-parent: what-is-git
 ---
 
 # Git-erminology

--- a/git/workflow/branches/viewing-your-tracking-branches.md
+++ b/git/workflow/branches/viewing-your-tracking-branches.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Tracking
     Branches](http://git-scm.com/book/en/v2/Git-Branching-Remote-Branches){documentation}
-parent: managing-branches
 ---
 
 # Viewing your tracking branches

--- a/git/workflow/help/how-to-unstage-a-staged-file.md
+++ b/git/workflow/help/how-to-unstage-a-staged-file.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Undoing Things Official
     Documentation](http://git-scm.com/book/en/v2/Git-Basics-Undoing-Things){website}
-parent: the-three-states-in-git
 ---
 
 # How to unstage a staged file

--- a/git/workflow/help/recover-lost-code.md
+++ b/git/workflow/help/recover-lost-code.md
@@ -2,8 +2,6 @@
 author: rosielowther
 type: normal
 category: must-know
-links: null
-parent: check-the-reflog
 ---
 
 # Recover lost code

--- a/git/workflow/staging-i/interactively-unstage-changes.md
+++ b/git/workflow/staging-i/interactively-unstage-changes.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - '[Git Reset](https://git-scm.com/docs/git-reset){documentation}'
   - '[Git Add](https://git-scm.com/docs/git-add){documentation}'
-parent: interactively-stage-patches
 ---
 
 # Interactively unstage changes

--- a/git/workflow/staging-ii/create-a-new-branch-from-a-stash.md
+++ b/git/workflow/staging-ii/create-a-new-branch-from-a-stash.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Stashing And
     Cleaning](http://git-scm.com/book/en/v2/Git-Tools-Stashing-and-Cleaning){documentation}
-parent: stashing-changes
 ---
 
 # Create a new branch from a stash

--- a/git/workflow/staging-ii/useful-stashing-options.md
+++ b/git/workflow/staging-ii/useful-stashing-options.md
@@ -2,7 +2,6 @@
 author: rosielowther
 type: normal
 category: feature
-parent: stashing-changes
 links:
   - >-
     [Stashing And

--- a/git/workflow/workflow/general-github-workflow.md
+++ b/git/workflow/workflow/general-github-workflow.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Understanding The Github
     Flow](https://guides.github.com/introduction/flow/){website}
-parent: git-hub
 ---
 
 # General **GitHub** workflow

--- a/javascript/core/errors/catch-is-block-scoped.md
+++ b/javascript/core/errors/catch-is-block-scoped.md
@@ -6,7 +6,6 @@ tags:
   - workout
   - deep
   - obscura
-parent: no-block-scope
 ---
 
 # `catch` Is Block Scoped

--- a/javascript/node/events/consuming-events.md
+++ b/javascript/node/events/consuming-events.md
@@ -9,7 +9,6 @@ links:
   - >-
     [Node
     Events](https://nodesource.com/blog/understanding-the-nodejs-event-loop/){website}
-parent: module-patterns
 ---
 
 # Consuming events

--- a/javascript/node/events/handling-event-errors.md
+++ b/javascript/node/events/handling-event-errors.md
@@ -7,7 +7,6 @@ tags:
   - workout
 links:
   - '[Node Errors](https://nodejs.org/api/errors.html){website}'
-parent: passing-arguments-to-listeners
 ---
 
 # Handling event errors

--- a/javascript/node/events/listening-to-events-just-once.md
+++ b/javascript/node/events/listening-to-events-just-once.md
@@ -9,8 +9,6 @@ tags:
   - introduction
   - workout
 
-parent: consuming-events
-
 ---
 
 # Listening to events just once

--- a/javascript/node/events/passing-arguments-to-listeners.md
+++ b/javascript/node/events/passing-arguments-to-listeners.md
@@ -9,7 +9,6 @@ links:
   - >-
     [Passing
     arguments](https://nodejs.org/api/events.html#events_passing_arguments_and_this_to_listeners){website}
-parent: synchronous-event-delivery
 ---
 
 # Passing arguments to listeners

--- a/javascript/node/events/synchronous-event-delivery.md
+++ b/javascript/node/events/synchronous-event-delivery.md
@@ -14,8 +14,6 @@ links:
     [Synchronous Event
     Delivery](https://blog.yld.io/2015/12/15/using-an-event-emitter/#.WI4ybbaLQy4){website}
 
-parent: listening-to-events-just-once
-
 ---
 
 # Event Delivery

--- a/javascript/node/events/synchronous-event-delivery.md
+++ b/javascript/node/events/synchronous-event-delivery.md
@@ -9,11 +9,6 @@ tags:
   - introduction
   - workout
 
-links:
-  - >-
-    [Synchronous Event
-    Delivery](https://blog.yld.io/2015/12/15/using-an-event-emitter/#.WI4ybbaLQy4){website}
-
 ---
 
 # Event Delivery

--- a/javascript/node/express-ii/cookie-session-in-express.md
+++ b/javascript/node/express-ii/cookie-session-in-express.md
@@ -4,7 +4,6 @@ type: normal
 category: how to
 links:
   - '[github.com](https://github.com/expressjs/cookie-session){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # `cookie-session` in **Express**

--- a/javascript/node/express-ii/gzip-compression-for-express.md
+++ b/javascript/node/express-ii/gzip-compression-for-express.md
@@ -4,7 +4,6 @@ type: normal
 category: must-know
 links:
   - '[github.com](https://github.com/expressjs/compression){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # GZIP compression for **Express**

--- a/javascript/node/express-ii/log-with-morgan-in-express.md
+++ b/javascript/node/express-ii/log-with-morgan-in-express.md
@@ -4,7 +4,6 @@ type: normal
 category: how to
 links:
   - '[github.com](https://github.com/expressjs/morgan){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # Log with `morgan` in **Express**

--- a/javascript/node/express-ii/session-handling-in-express.md
+++ b/javascript/node/express-ii/session-handling-in-express.md
@@ -6,7 +6,6 @@ links:
   - >-
     [codeforgeek.com](https://codeforgeek.com/2014/10/express-complete-tutorial-part-4/){website}
   - '[github.com](https://github.com/expressjs/session){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # Session handling in **Express**

--- a/javascript/node/express-ii/vhost-in-express.md
+++ b/javascript/node/express-ii/vhost-in-express.md
@@ -4,7 +4,6 @@ type: normal
 category: how to
 links:
   - '[github.com](https://github.com/expressjs/vhost){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # `vhost` in **Express**

--- a/javascript/node/express/body-parser-in-express.md
+++ b/javascript/node/express/body-parser-in-express.md
@@ -6,7 +6,6 @@ links:
   - >-
     [medium.com](https://medium.com/@adamzerner/how-bodyparser-works-247897a93b90#.34biejvm1){website}
   - '[github.com](https://github.com/expressjs/body-parser){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # `body-parser` in **Express**

--- a/javascript/node/express/error-handler-in-express.md
+++ b/javascript/node/express/error-handler-in-express.md
@@ -4,7 +4,6 @@ type: normal
 category: how to
 links:
   - '[github.com](https://github.com/expressjs/errorhandler){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # Error handler in **Express**

--- a/javascript/node/express/response-object-additional-properties-in-express.md
+++ b/javascript/node/express/response-object-additional-properties-in-express.md
@@ -4,7 +4,6 @@ type: normal
 category: must-know
 links:
   - '[node-tricks.com](http://node-tricks.com/response-object/){website}'
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # response object additional properties in **Express**

--- a/javascript/node/express/response-object-additional-properties-in-express.md
+++ b/javascript/node/express/response-object-additional-properties-in-express.md
@@ -1,13 +1,13 @@
 ---
 author: catalin
+
 type: normal
+
 category: must-know
-links:
-  - '[node-tricks.com](http://node-tricks.com/response-object/){website}'
+
 ---
 
-# response object additional properties in **Express**
-
+# Response Object Additional Properties in Express
 
 ---
 

--- a/javascript/node/express/using-express-4-0-router.md
+++ b/javascript/node/express/using-express-4-0-router.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [scotch.io](https://scotch.io/tutorials/learn-to-use-the-new-router-in-expressjs-4){website}
-parent: easy-way-to-deliver-html-pages-with-express
 ---
 
 # Using **Express 4.0** `router`

--- a/javascript/node/intro-node/executing-programs-with-node.md
+++ b/javascript/node/intro-node/executing-programs-with-node.md
@@ -7,7 +7,6 @@ tags:
 links:
   - >-
     [nodeguide.com](http://nodeguide.com/beginner.html#the-interactive-node.js-shell){website}
-parent: the-repl-terminal
 ---
 
 # Executing programs with Node

--- a/javascript/node/intro-node/installing-node-js.md
+++ b/javascript/node/intro-node/installing-node-js.md
@@ -2,8 +2,6 @@
 author: tommarshall
 type: normal
 category: must-know
-inAlgoPool: false
-parent: what-is-nodejs
 tags:
   - introduction
 links:

--- a/javascript/node/intro-node/npm-nodes-package-manager.md
+++ b/javascript/node/intro-node/npm-nodes-package-manager.md
@@ -6,7 +6,6 @@ tags:
   - introduction
 links:
   - '[npmjs.com](https://www.npmjs.com/){website}'
-parent: executing-programs-with-node
 ---
 
 # NPM, Node's Package Manager

--- a/javascript/node/intro-node/the-repl-terminal.md
+++ b/javascript/node/intro-node/the-repl-terminal.md
@@ -7,7 +7,6 @@ tags:
 links:
   - >-
     [tutorialsteacher.com](http://www.tutorialsteacher.com/nodejs/nodejs-console-repl){website}
-parent: installing-node-js
 ---
 
 # The REPL Terminal

--- a/javascript/node/modules/local-modules.md
+++ b/javascript/node/modules/local-modules.md
@@ -9,7 +9,6 @@ links:
   - >-
     [Local
     Modules](http://www.tutorialsteacher.com/nodejs/nodejs-local-modules){website}
-parent: the-http-module-for-servers
 ---
 
 # Local Modules

--- a/javascript/node/modules/module-patterns.md
+++ b/javascript/node/modules/module-patterns.md
@@ -9,7 +9,6 @@ links:
   - >-
     [Node Module
     Patterns](https://darrenderidder.github.io/talks/ModulePatterns/#/5){website}
-parent: local-modules
 ---
 
 # Module patterns

--- a/javascript/node/modules/requiring-and-exporting.md
+++ b/javascript/node/modules/requiring-and-exporting.md
@@ -9,7 +9,6 @@ links:
   - >-
     [Node
     Modules](https://www.bennadel.com/blog/2169-where-does-node-js-and-require-look-for-modules.htm){website}
-parent: what-are-node-modules
 ---
 
 # Requiring and Exporting

--- a/javascript/node/modules/what-are-node-modules.md
+++ b/javascript/node/modules/what-are-node-modules.md
@@ -7,7 +7,6 @@ tags:
   - workout
 links:
   - '[Node Modules](http://book.mixu.net/node/ch8.html){website}'
-parent: npm-nodes-package-manager
 ---
 
 # What are Node Modules?

--- a/javascript/node/streams/chaining-readable-streams.md
+++ b/javascript/node/streams/chaining-readable-streams.md
@@ -9,7 +9,6 @@ tags:
 links:
   - >-
     [Chaining](http://www.naeemrana.com/node-js/node-js-streams-pipe-and-chaining/){website}
-parent: piping-readable-streams
 ---
 
 # Chaining Readable Streams

--- a/javascript/node/streams/piping-readable-streams.md
+++ b/javascript/node/streams/piping-readable-streams.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Piping
     Streams](https://www.sandersdenardi.com/readable-writable-transform-streams-node/){website}
-parent: readable-streams
 ---
 
 # Piping Readable Streams

--- a/javascript/node/streams/what-are-streams.md
+++ b/javascript/node/streams/what-are-streams.md
@@ -7,7 +7,6 @@ tags:
   - workout
 links:
   - '[Node Streams](https://maxogden.com/node-streams.html){website}'
-parent: handling-event-errors
 ---
 
 # What are Streams?

--- a/javascript/node/streams/writable-streams.md
+++ b/javascript/node/streams/writable-streams.md
@@ -8,7 +8,6 @@ tags:
 category: must-know
 links:
   - '[Writable Streams](https://gist.github.com/joyrexus/10026630){website}'
-parent: chaining-readable-streams
 ---
 
 # Writable Streams

--- a/javascript/node/web-servers/the-http-module-for-servers.md
+++ b/javascript/node/web-servers/the-http-module-for-servers.md
@@ -7,7 +7,6 @@ tags:
   - workout
 links:
   - '[The HTTP Module](https://davidwalsh.name/nodejs-http-request){website}'
-parent: requiring-and-exporting
 ---
 
 # The `http` module for servers

--- a/javascript/npm/features-i/available-binaries-for-scripting.md
+++ b/javascript/npm/features-i/available-binaries-for-scripting.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: how to
-parent: npm-scripting
 tags:
   - introduction
   - workout

--- a/javascript/npm/features-i/npm-scripting.md
+++ b/javascript/npm/features-i/npm-scripting.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: how to
-parent: how-npm3-handles-dependencies
 tags:
   - introduction
   - workout

--- a/javascript/npm/features-i/npm-variables.md
+++ b/javascript/npm/features-i/npm-variables.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: feature
-parent: available-binaries-for-scripting
 tags:
   - introduction
   - workout

--- a/javascript/npm/features-i/remote-scripts.md
+++ b/javascript/npm/features-i/remote-scripts.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: feature
-parent: scripts-lifecycle
 tags:
   - introduction
   - workout

--- a/javascript/npm/features-i/scripts-lifecycle.md
+++ b/javascript/npm/features-i/scripts-lifecycle.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: npm-variables
 tags:
   - introduction
   - workout

--- a/javascript/npm/features-ii/abbreviate-commands-in-npm.md
+++ b/javascript/npm/features-ii/abbreviate-commands-in-npm.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: feature
-parent: check-data-about-a-package
 tags:
   - obscura
 ---

--- a/javascript/npm/features-ii/environmental-variables-and-flags-for-npm.md
+++ b/javascript/npm/features-ii/environmental-variables-and-flags-for-npm.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: best practice
-parent: check-data-about-a-package
 tags:
   - workout
   - deep

--- a/javascript/npm/features-ii/npm-verifies-sha1-hashes-of-packages.md
+++ b/javascript/npm/features-ii/npm-verifies-sha1-hashes-of-packages.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: feature
-parent: check-data-about-a-package
 tags:
   - workout
   - deep

--- a/javascript/npm/features-ii/optionaldependencies-in-npm.md
+++ b/javascript/npm/features-ii/optionaldependencies-in-npm.md
@@ -5,7 +5,6 @@ category: feature
 tags:
   - workout
   - deep
-parent: check-data-about-a-package
 links:
   - >-
     [docs.npmjs.com](https://docs.npmjs.com/files/package.json#optionaldependencies){website}

--- a/javascript/npm/features-ii/passing-through-command-line-arguments-in-npm-scripts.md
+++ b/javascript/npm/features-ii/passing-through-command-line-arguments-in-npm-scripts.md
@@ -5,7 +5,6 @@ category: feature
 links:
   - >-
     [www.marcusoft.net](http://www.marcusoft.net/2015/08/npm-scripting-configs-and-arguments.html#passing-through-command-line-argument){website}
-parent: check-data-about-a-package
 tags:
   - introduction
   - workout

--- a/javascript/npm/intro-npm/package-json.md
+++ b/javascript/npm/intro-npm/package-json.md
@@ -7,7 +7,6 @@ tags:
 links:
   - >-
     [docs.npmjs.com](https://docs.npmjs.com/getting-started/using-a-package.json){website}
-parent: setting-up-npm
 ---
 
 # `package.json`

--- a/javascript/npm/intro-npm/semantic-versioning.md
+++ b/javascript/npm/intro-npm/semantic-versioning.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: package-json
 tags:
   - introduction
   - workout

--- a/javascript/npm/intro-npm/setting-up-npm.md
+++ b/javascript/npm/intro-npm/setting-up-npm.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: why-use-npm
 tags:
   - introduction
 ---

--- a/javascript/npm/intro-npm/why-use-npm.md
+++ b/javascript/npm/intro-npm/why-use-npm.md
@@ -1,15 +1,16 @@
 ---
 author: mihaiberq
+
 type: normal
+
 category: must-know
+
 tags:
   - introduction
-links:
-  - >-
-    [andrewhfarmer.com](http://andrewhfarmer.com/javascript-frontend-package-managers/){website}
+
 ---
 
-# Why should I use npm?
+# Why Should I Use npm?
 
 
 ---

--- a/javascript/npm/intro-npm/why-use-npm.md
+++ b/javascript/npm/intro-npm/why-use-npm.md
@@ -7,7 +7,6 @@ tags:
 links:
   - >-
     [andrewhfarmer.com](http://andrewhfarmer.com/javascript-frontend-package-managers/){website}
-parent: what-is-npm
 ---
 
 # Why should I use npm?

--- a/javascript/npm/packages-modules/dependencies.md
+++ b/javascript/npm/packages-modules/dependencies.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: private-packages
 tags:
   - introduction
   - workout

--- a/javascript/npm/packages-modules/deprecated-peer-dependencies.md
+++ b/javascript/npm/packages-modules/deprecated-peer-dependencies.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: feature
-parent: dependencies
 tags:
   - workout
   - deep

--- a/javascript/npm/packages-modules/how-npm3-handles-dependencies.md
+++ b/javascript/npm/packages-modules/how-npm3-handles-dependencies.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: feature
-parent: deprecated-peer-dependencies
 tags:
   - workout
   - deep

--- a/javascript/npm/packages-modules/packages-vs-modules.md
+++ b/javascript/npm/packages-modules/packages-vs-modules.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: must-know
-parent: semantic-versioning
 tags:
   - introduction
   - workout

--- a/javascript/npm/packages-modules/private-packages.md
+++ b/javascript/npm/packages-modules/private-packages.md
@@ -9,7 +9,6 @@ tags:
 links:
   - >-
     [docs.npmjs.com](https://docs.npmjs.com/getting-started/scoped-packages){website}
-parent: packages-vs-modules
 ---
 
 # Scoped packages

--- a/javascript/npm/publishing/check-data-about-a-package.md
+++ b/javascript/npm/publishing/check-data-about-a-package.md
@@ -8,7 +8,6 @@ tags:
   - deep
 links:
   - '[docs.npmjs.com](https://docs.npmjs.com/cli/view){website}'
-parent: how-to-publish-your-own-packages
 ---
 
 # Check the details of a package

--- a/javascript/npm/publishing/creating-a-node-module.md
+++ b/javascript/npm/publishing/creating-a-node-module.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: how to
-parent: remote-scripts
 tags:
   - workout
   - deep

--- a/javascript/npm/publishing/how-to-publish-your-own-packages.md
+++ b/javascript/npm/publishing/how-to-publish-your-own-packages.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: how to
-parent: tests
 tags:
   - introduction
   - workout

--- a/javascript/npm/publishing/package-distribution-tags.md
+++ b/javascript/npm/publishing/package-distribution-tags.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: how to
-parent: check-data-about-a-package
 links:
   - '[docs.npmjs.com](https://docs.npmjs.com/cli/dist-tag){website}'
 tags:

--- a/javascript/npm/publishing/prepare-your-module-for-publishing.md
+++ b/javascript/npm/publishing/prepare-your-module-for-publishing.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: how to
-parent: creating-a-node-module
 tags:
   - introduction
   - workout

--- a/javascript/npm/publishing/registry-user-accounts-for-npm.md
+++ b/javascript/npm/publishing/registry-user-accounts-for-npm.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: how to
-parent: check-data-about-a-package
 tags:
   - workout
   - deep

--- a/javascript/npm/publishing/tests.md
+++ b/javascript/npm/publishing/tests.md
@@ -2,7 +2,6 @@
 author: mihaiberq
 type: normal
 category: how to
-parent: prepare-your-module-for-publishing
 tags:
   - introduction
   - workout

--- a/javascript/npm/tools-i/bump-package-version-in-npm.md
+++ b/javascript/npm/tools-i/bump-package-version-in-npm.md
@@ -7,7 +7,6 @@ tags:
   - introduction
 links:
   - '[docs.npmjs.com](https://docs.npmjs.com/cli/version){website}'
-parent: check-data-about-a-package
 ---
 
 # Bump package version in npm

--- a/javascript/npm/tools-i/deprecate-npm-packages.md
+++ b/javascript/npm/tools-i/deprecate-npm-packages.md
@@ -8,7 +8,6 @@ tags:
   - introduction
 links:
   - '[docs.npmjs.com](https://docs.npmjs.com/cli/deprecate){website}'
-parent: check-data-about-a-package
 ---
 
 # Deprecate npm packages

--- a/javascript/npm/tools-i/lock-down-dependency-versions-by-shrinkwrapping.md
+++ b/javascript/npm/tools-i/lock-down-dependency-versions-by-shrinkwrapping.md
@@ -9,7 +9,6 @@ tags:
 links:
   - >-
     [nodejs.org](https://nodejs.org/en/blog/npm/managing-node-js-dependencies-with-shrinkwrap/){website}
-parent: check-data-about-a-package
 ---
 
 # Lock down dependency versions by shrinkwrapping

--- a/javascript/npm/tools-i/manage-local-node-modules-with-npm-link.md
+++ b/javascript/npm/tools-i/manage-local-node-modules-with-npm-link.md
@@ -7,7 +7,6 @@ tags:
   - introduction
 links:
   - '[docs.npmjs.com](https://docs.npmjs.com/cli/link){website}'
-parent: check-data-about-a-package
 ---
 
 # Manage local node modules with `npm link`

--- a/javascript/npm/tools-i/manipulate-npm-packages-cache.md
+++ b/javascript/npm/tools-i/manipulate-npm-packages-cache.md
@@ -8,7 +8,6 @@ tags:
   - new
 links:
   - '[docs.npmjs.com](https://docs.npmjs.com/cli/cache){website}'
-parent: check-data-about-a-package
 ---
 
 # Manipulate npm packages cache

--- a/linux/jobs-and-processes-data-manipulation/crontab/common-issue-with-scripts-in-cron.md
+++ b/linux/jobs-and-processes-data-manipulation/crontab/common-issue-with-scripts-in-cron.md
@@ -7,7 +7,6 @@ tags:
   - cron
   - script
   - executable
-parent: practical-cron
 ---
 
 # Common issue with scripts in `cron`

--- a/linux/jobs-and-processes-data-manipulation/crontab/crontab-newline-issue.md
+++ b/linux/jobs-and-processes-data-manipulation/crontab/crontab-newline-issue.md
@@ -9,7 +9,6 @@ tags:
   - newline
   - issue
   - trick
-parent: practical-cron
 ---
 
 # `Crontab` newline issue

--- a/linux/jobs-and-processes-data-manipulation/crontab/fixing-the-shell-in-cron.md
+++ b/linux/jobs-and-processes-data-manipulation/crontab/fixing-the-shell-in-cron.md
@@ -7,7 +7,6 @@ tags:
   - cron
   - shell
   - null
-parent: practical-cron
 ---
 
 # Fixing the shell in cron

--- a/linux/networking-and-security/security/lockdown-cronjobs.md
+++ b/linux/networking-and-security/security/lockdown-cronjobs.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: tip
-parent: practical-cron
 ---
 
 # Lockdown **Cronjobs**

--- a/linux/networking-and-security/ssh-remote/play-sounds-remotely.md
+++ b/linux/networking-and-security/ssh-remote/play-sounds-remotely.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: how to
-parent: ssh-pipes
 ---
 
 # Play sounds remotely

--- a/linux/networking-and-security/ssh-remote/run-local-scripts-remotely.md
+++ b/linux/networking-and-security/ssh-remote/run-local-scripts-remotely.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: how to
-parent: ssh-pipes
 ---
 
 # Run local scripts remotely

--- a/linux/system-and-package-management/system-monitoring-ii/finding-open-files-with-lsof.md
+++ b/linux/system-and-package-management/system-monitoring-ii/finding-open-files-with-lsof.md
@@ -10,7 +10,6 @@ tags:
 links:
   - '[inux.die.net](https://linux.die.net/man/8/lsof){website}'
 notes: to review parent
-parent: list-currently-logged-in-users
 ---
 
 # Finding Open Files With `lsof`

--- a/linux/system-and-package-management/system-recipes/changing-the-tmp-cleanup-frequency.md
+++ b/linux/system-and-package-management/system-recipes/changing-the-tmp-cleanup-frequency.md
@@ -8,7 +8,6 @@ tags:
   - tmp
   - temp
   - cleanup
-parent: practical-cron
 ---
 
 # Changing the `/tmp` cleanup frequency

--- a/linux/system-and-package-management/utility-management/removing-ppas.md
+++ b/linux/system-and-package-management/utility-management/removing-ppas.md
@@ -12,7 +12,6 @@ tags:
   - ppa-purge
   - install
   - repository
-parent: using-ppas
 ---
 
 # Removing PPAs

--- a/linux/user-and-file-management/file-permissions/set-file-permissions-for-users.md
+++ b/linux/user-and-file-management/file-permissions/set-file-permissions-for-users.md
@@ -7,7 +7,6 @@ links:
     [Managing Group
     Access](http://www.yolinux.com/TUTORIALS/LinuxTutorialManagingGroups.html){website}
   - '[Unix Permissions](https://drawings.jvns.ca/permissions/){illustration}'
-parent: understanding-umask
 ---
 
 # Set file permissions for users

--- a/linux/user-and-file-management/pipeline-tools/shebang-explained.md
+++ b/linux/user-and-file-management/pipeline-tools/shebang-explained.md
@@ -8,7 +8,6 @@ tags:
   - shebang
   - interpreter
   - workout
-parent: set-file-permissions-for-users
 notes: Approved by Jordan
 ---
 

--- a/linux/user-and-file-management/super-users-and-root/get-file-permissions-in-octal-form.md
+++ b/linux/user-and-file-management/super-users-and-root/get-file-permissions-in-octal-form.md
@@ -10,7 +10,6 @@ tags:
   - ssh
   - stat
   - introduction
-parent: understanding-umask
 ---
 
 # Get file permissions in octal form

--- a/python/core/advanced-queues/prioritize-your-queue.md
+++ b/python/core/advanced-queues/prioritize-your-queue.md
@@ -1,9 +1,13 @@
 ---
 author: catalin
+
 type: normal
+
 category: how to
+
 links:
-  - '[docs.python.org](https://docs.python.org/2/library/queue.htmt){website}'
+  - '[queue](https://docs.python.org/3/library/queue.html){documentation}'
+
 ---
 
 # Prioritize your `queue`

--- a/python/core/advanced-queues/prioritize-your-queue.md
+++ b/python/core/advanced-queues/prioritize-your-queue.md
@@ -4,7 +4,6 @@ type: normal
 category: how to
 links:
   - '[docs.python.org](https://docs.python.org/2/library/queue.htmt){website}'
-parent: a-thread-safe-queue
 ---
 
 # Prioritize your `queue`

--- a/python/core/advanced-queues/queue-s-and-threads.md
+++ b/python/core/advanced-queues/queue-s-and-threads.md
@@ -7,11 +7,6 @@ links:
     [docs.python.org](https://docs.python.org/3.5/library/stdtypes.html#memory-views){website}
   - >-
     [www.troyfawkes.com](http://www.troyfawkes.com/learn-python-multithreading-queues-basics/){website}
-parent: a-thread-safe-queue
-notes: |
-  The program does not work as it is. It has a syntax error, in this line:
-      print q.get()
-  the print should have parentheses since this is for Python 3.  Fixed.
 ---
 
 # Queues and threads

--- a/python/core/advanced-queues/special-queue-methods.md
+++ b/python/core/advanced-queues/special-queue-methods.md
@@ -9,8 +9,6 @@ links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/queue.html#queue-objects){website}
 
-parent: a-thread-safe-queue
-
 ---
 
 # Special `queue` methods

--- a/python/core/advanced-referencing/weakref-callbacks.md
+++ b/python/core/advanced-referencing/weakref-callbacks.md
@@ -4,7 +4,6 @@ type: normal
 category: how to
 links:
   - '[pymotw.com](https://pymotw.com/2/weakref/#references){website}'
-parent: implementing-weak-references
 ---
 
 # `weakref` callbacks

--- a/python/core/advanced-referencing/weakref-proxies.md
+++ b/python/core/advanced-referencing/weakref-proxies.md
@@ -4,7 +4,6 @@ type: normal
 category: tip
 links:
   - '[pymotw.com](https://pymotw.com/2/weakref/#proxies){website}'
-parent: implementing-weak-references
 ---
 
 # `weakref` proxies

--- a/python/core/bits-bytes-hexadecimals/bytearray-objects.md
+++ b/python/core/bits-bytes-hexadecimals/bytearray-objects.md
@@ -5,7 +5,6 @@ category: feature
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/stdtypes.html#bytearray-objects){website}
-parent: bytes-type
 ---
 
 # `bytearray` objects

--- a/python/core/bits-bytes-hexadecimals/operations-with-bytes-and-bytearray.md
+++ b/python/core/bits-bytes-hexadecimals/operations-with-bytes-and-bytearray.md
@@ -5,8 +5,6 @@ category: feature
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/stdtypes.html#bytes-and-bytearray-operations){website}
-parent: bytes-type
-notes: ''
 ---
 
 # Operations with `bytes` and `bytearray`

--- a/python/core/classes-ii/class-vs-instance-variables.md
+++ b/python/core/classes-ii/class-vs-instance-variables.md
@@ -5,13 +5,6 @@ category: tip
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/tutorial/classes.html#class-and-instance-variables){website}
-parent: method-objects
-notes: >
-  Insight needs to be rewritten. There is overuse of the string Enki (caps and
-  small) for different things like class name and class level var. Also, the
-  values passed to the constructor are numbers like 0.2.3 etc. which are
-  meaningless and will be confusing to at least beginners. Simple values like
-  'a' and 'b', or 1 and 2 could be used instead. --> updated.
 ---
 
 # **Class** vs. **Instance** variables

--- a/python/core/classes-ii/method-objects.md
+++ b/python/core/classes-ii/method-objects.md
@@ -5,7 +5,6 @@ category: tip
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/tutorial/classes.html#method-objects){website}
-parent: instance-objects
 notes: >
   Using the word Enki or enki in many places such as for class name, instance
   name, return value (as in this example), is confusing to readers. Use

--- a/python/core/deep-into-collections/best-way-to-implement-a-simple-queue.md
+++ b/python/core/deep-into-collections/best-way-to-implement-a-simple-queue.md
@@ -5,7 +5,6 @@ category: best practice
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/tutorial/datastructures.html#using-lists-as-queues){website}
-parent: double-ended-queues-with-deque
 notes: >-
   Insight content is correct. But the deque class has about 15 methods. Suggest
   adding a few examples of use of other methods.

--- a/python/core/deep-into-collections/double-ended-queues-with-deque.md
+++ b/python/core/deep-into-collections/double-ended-queues-with-deque.md
@@ -7,7 +7,6 @@ links:
     [pythontips.com](http://pythontips.com/2014/07/02/an-intro-to-deque-module/){website}
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/collections.html#deque-objects){website}
-parent: get-more-with-collections
 ---
 
 # Double ended queues with `deque`

--- a/python/core/deep-into-collections/enhance-your-tuple-s.md
+++ b/python/core/deep-into-collections/enhance-your-tuple-s.md
@@ -5,7 +5,6 @@ category: feature
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/collections.html#chainmap-examples-and-recipes){website}
-parent: get-more-with-collections
 notes: >
   Issues found:
 

--- a/python/core/more-on-dictionaries/dictionary-view-objects.md
+++ b/python/core/more-on-dictionaries/dictionary-view-objects.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/stdtypes.html#dictionary-view-objects){website}
-parent: dictionary-standard-mapping-type
 ---
 
 # `Dictionary` view objects

--- a/python/core/more-on-lists/using-a-list-as-a-stack.md
+++ b/python/core/more-on-lists/using-a-list-as-a-stack.md
@@ -5,7 +5,6 @@ category: how to
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/tutorial/datastructures.html#using-lists-as-stacks){website}
-parent: built-in-list-methods
 ---
 
 # Using a `list` as a `stack`

--- a/python/core/more-on-sets/immutable-sets-with-frozenset.md
+++ b/python/core/more-on-sets/immutable-sets-with-frozenset.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/stdtypes.html#set-types-set-frozenset){website}
-parent: working-with-set-s
 notes: >
   By Vasudev:
 

--- a/python/core/more-on-sets/set-operations.md
+++ b/python/core/more-on-sets/set-operations.md
@@ -5,7 +5,6 @@ category: feature
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/stdtypes.html#set-types-set-frozenset){website}
-parent: working-with-set-s
 ---
 
 # `set` operations

--- a/python/core/playing-with-time/datetime-object.md
+++ b/python/core/playing-with-time/datetime-object.md
@@ -6,7 +6,6 @@ inAlgoPool: false
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/library/datetime.html#datetime-objects){website}
-parent: time-object
 ---
 
 # `datetime` object

--- a/python/core/playing-with-time/time-object.md
+++ b/python/core/playing-with-time/time-object.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: feature
-parent: datetime-module
 links:
   - >-
     [Time

--- a/python/core/playing-with-time/timedelta-object.md
+++ b/python/core/playing-with-time/timedelta-object.md
@@ -7,7 +7,6 @@ links:
     [timedelta
     Objects](https://docs.python.org/3.5/library/datetime.html#timedelta-objects){website}
   - '[Playground](https://repl.it/@enkicontent/PythonTimedelta){website}'
-parent: datetime-object
 ---
 
 # Date arithmetics with `timedelta`

--- a/python/core/string-recipes/recipe-to-normalize-text.md
+++ b/python/core/string-recipes/recipe-to-normalize-text.md
@@ -4,7 +4,6 @@ type: normal
 category: how to
 links:
   - '[gist.github.com](https://gist.github.com/j4mie/557354){website}'
-parent: unicode-character-database-at-your-hands
 ---
 
 # Recipe to normalize text

--- a/python/core/utilities-ii/get-the-similarity-ratio-of-two-sequences.md
+++ b/python/core/utilities-ii/get-the-similarity-ratio-of-two-sequences.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: how to
-parent: compare-sequences-with-difflib
 ---
 
 # Get the similarity ratio of two sequences

--- a/python/core/utilities-ii/working-with-junk-data.md
+++ b/python/core/utilities-ii/working-with-junk-data.md
@@ -5,7 +5,6 @@ category: how to
 links:
   - >-
     [docs.python.org](https://docs.python.org/2/library/difflib.html#sequencematcher-objects){website}
-parent: compare-sequences-with-difflib
 ---
 
 # Working with junk data

--- a/python/functional-programming/comprehension/dictionary-comprehension.md
+++ b/python/functional-programming/comprehension/dictionary-comprehension.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [www.bogotobogo.com](http://www.bogotobogo.com/python/python_dictionary_comprehension_with_zip_from_list.php){website}
-parent: list-comprehension
 notes: >
   Added a slightly more advanced example using a dict to count frequencies of
   lower case letters.

--- a/python/functional-programming/comprehension/nested-lists-comprehension.md
+++ b/python/functional-programming/comprehension/nested-lists-comprehension.md
@@ -5,7 +5,6 @@ category: how to
 links:
   - >-
     [docs.python.org](https://docs.python.org/3.5/tutorial/datastructures.html#nested-list-comprehensions){website}
-parent: list-comprehension
 ---
 
 # Nested lists comprehension

--- a/python/functional-programming/comprehension/set-comprehension.md
+++ b/python/functional-programming/comprehension/set-comprehension.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [python-3-patterns-idioms-test.readthedocs.org](http://python-3-patterns-idioms-test.readthedocs.org/en/latest/Comprehensions.html#set-comprehensions){website}
-parent: list-comprehension
 notes: >-
   Added the point that the list-to-set comprehension will work even if the list
   contains duplicates.

--- a/react/intermediary/props-i/react-custom-proptype-s-to-be-required.md
+++ b/react/intermediary/props-i/react-custom-proptype-s-to-be-required.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Custom PropType validation with
     React](http://www.ian-thomas.net/custom-proptype-validation-with-react/){website}
-parent: custom-validations-for-props
 ---
 
 # Require custom `propTypes` validators

--- a/react/intermediary/props-i/react-custom-validations-for-props.md
+++ b/react/intermediary/props-i/react-custom-validations-for-props.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Putting React custom PropTypes to
     work](http://rjzaworski.com/2015/01/putting-react-custom-proptypes-to-work){website}
-parent: enhanced-prop-validation
 ---
 
 # Custom validator functions for `props`

--- a/react/intermediary/props-i/react-custom-validations-for-props.md
+++ b/react/intermediary/props-i/react-custom-validations-for-props.md
@@ -1,15 +1,13 @@
 ---
 author: catalin
+
 type: normal
+
 category: feature
-links:
-  - >-
-    [Putting React custom PropTypes to
-    work](http://rjzaworski.com/2015/01/putting-react-custom-proptypes-to-work){website}
+
 ---
 
-# Custom validator functions for `props`
-
+# Custom Validator Functions for props
 
 ---
 
@@ -43,7 +41,7 @@ function lengthCheck(
         : new Error(propName + " too long");
     }
   }
-  //assume everything is ok
+  // assume everything is ok
   return null;
 }
 ```
@@ -67,7 +65,7 @@ What are the basic arguments of a validator function?
 
 ```jsx
 function (???, ???, ???) {
- //check here
+ // check here
 }
 ```
 
@@ -88,7 +86,7 @@ What are the basic arguments of a validator function?
 
 ```jsx
 function (???, ???, ???) {
- //check here
+ // check here
 }
 ```
 

--- a/react/intermediary/props-i/react-default-values-for-props.md
+++ b/react/intermediary/props-i/react-default-values-for-props.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Default prop
     values](https://facebook.github.io/react/docs/typechecking-with-proptypes.html#default-prop-values){website}
-parent: validate-for-required-props
 ---
 
 # Default values for props

--- a/react/intermediary/props-i/react-enhanced-prop-validation.md
+++ b/react/intermediary/props-i/react-enhanced-prop-validation.md
@@ -7,7 +7,6 @@ links:
     [Type checking with
     PropTypes](https://facebook.github.io/react/docs/typechecking-with-proptypes.html#react.proptypes){website}
   - '[PropTypes Library](https://www.npmjs.com/package/prop-types){website}'
-parent: default-values-for-props
 ---
 
 # Enhanced `props` Validation

--- a/react/intermediary/props-i/react-prop-validation.md
+++ b/react/intermediary/props-i/react-prop-validation.md
@@ -7,7 +7,6 @@ links:
     [Type checking with
     PropTypes](https://facebook.github.io/react/docs/typechecking-with-proptypes.html#react.proptypes){website}
   - '[PropTypes library](https://www.npmjs.com/package/prop-types){website}'
-parent: destructuring-arguments
 ---
 
 # `props` Validation

--- a/react/intermediary/props-ii/react-children-in-react.md
+++ b/react/intermediary/props-ii/react-children-in-react.md
@@ -9,7 +9,6 @@ links:
   - >-
     [React
     Children](https://facebook.github.io/react/docs/react-api.html#reactchildren){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Children in React

--- a/react/intermediary/props-ii/react-children-methods.md
+++ b/react/intermediary/props-ii/react-children-methods.md
@@ -6,7 +6,6 @@ links:
   - >-
     [React
     Children](https://facebook.github.io/react/docs/top-level-api.html#reactchildren){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # `React.Children` methods

--- a/react/intermediary/props-ii/react-dealing-with-this-props-children.md
+++ b/react/intermediary/props-ii/react-dealing-with-this-props-children.md
@@ -6,7 +6,6 @@ links:
   - >-
     [React
     Children](https://facebook.github.io/react/docs/top-level-api.html#reactchildren){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Dealing with `this.props.children`

--- a/react/intermediary/props-ii/react-props-in-constructor-state-is-an-anti-pattern.md
+++ b/react/intermediary/props-ii/react-props-in-constructor-state-is-an-anti-pattern.md
@@ -2,7 +2,6 @@
 author: tommarshall
 type: normal
 category: tip
-parent: custom-proptype-s-to-be-required
 ---
 
 # Props in constructor's state

--- a/react/intermediary/props-ii/react-specify-a-single-child.md
+++ b/react/intermediary/props-ii/react-specify-a-single-child.md
@@ -10,7 +10,6 @@ links:
     [Requiring Single
     Child](https://facebook.github.io/react/docs/typechecking-with-proptypes.html#requiring-single-child){website}
 
-parent: custom-proptype-s-to-be-required
 
 ---
 

--- a/react/intermediary/props-ii/react-type-of-the-children-props.md
+++ b/react/intermediary/props-ii/react-type-of-the-children-props.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Children in
     JSX](https://facebook.github.io/react/docs/jsx-in-depth.html#children-in-jsx){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Type of the Children props

--- a/react/intermediary/props-iii/react-clone-elements-in-react.md
+++ b/react/intermediary/props-iii/react-clone-elements-in-react.md
@@ -10,7 +10,6 @@ links:
     [cloneElement()
     Documentation](https://facebook.github.io/react/docs/top-level-api.html#cloneelement){website}
 
-parent: custom-proptype-s-to-be-required
 
 ---
 

--- a/react/intermediary/props-iii/react-shallow-compare-in-function-components.md
+++ b/react/intermediary/props-iii/react-shallow-compare-in-function-components.md
@@ -6,7 +6,6 @@ links:
   - >-
     [React.memo Official
     Documentation](https://facebook.github.io/react/docs/react-api.html#reactmemo){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Shallow compare in function components

--- a/react/intermediary/props-iii/react-shallow-compare-in-react.md
+++ b/react/intermediary/props-iii/react-shallow-compare-in-react.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Pure
     Components](https://facebook.github.io/react/docs/react-api.html#reactpurecomponent){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Shallow compare in React

--- a/react/intermediary/props-iii/react-shortcut-for-transferring-props.md
+++ b/react/intermediary/props-iii/react-shortcut-for-transferring-props.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Spread
     attributes](https://facebook.github.io/react/docs/jsx-in-depth.html#spread-attributes){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Shortcut for transferring props

--- a/react/intermediary/props-iii/react-use-proptypes-on-stateless-components.md
+++ b/react/intermediary/props-iii/react-use-proptypes-on-stateless-components.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Type checking with
     PropTypes](http://facebook.github.io/react/docs/typechecking-with-proptypes){website}
-parent: custom-proptype-s-to-be-required
 notes: >-
   Originally from Dan Abramov
   http://twitter.com/dan_abramov/status/658710159125037056 but don't have

--- a/react/introduction/basics-i/react-component-lifecycle-methods.md
+++ b/react/introduction/basics-i/react-component-lifecycle-methods.md
@@ -9,7 +9,6 @@ links:
   - >-
     [Lifecycle methods
     diagram](http://projects.wojtekmaj.pl/react-lifecycle-methods-diagram/){website}
-parent: the-component-lifecycle
 ---
 
 # Component lifecycle methods

--- a/react/introduction/basics-i/react-event-handling-in-react.md
+++ b/react/introduction/basics-i/react-event-handling-in-react.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Handling
     events](https://facebook.github.io/react/docs/handling-events.html){website}
-parent: forms-in-react
 ---
 
 # Event handling in React

--- a/react/introduction/basics-i/react-forms-in-react.md
+++ b/react/introduction/basics-i/react-forms-in-react.md
@@ -4,7 +4,6 @@ type: normal
 category: must-know
 links:
   - '[Forms](https://facebook.github.io/react/docs/forms.html){website}'
-parent: rendering-multiple-components
 ---
 
 # Forms in React

--- a/react/introduction/basics-i/react-rendering-multiple-components.md
+++ b/react/introduction/basics-i/react-rendering-multiple-components.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Lists and
     keys](https://facebook.github.io/react/docs/lists-and-keys.html){website}
-parent: component-lifecycle-methods
 ---
 
 # Rendering multiple components

--- a/react/introduction/basics-i/react-the-component-lifecycle.md
+++ b/react/introduction/basics-i/react-the-component-lifecycle.md
@@ -9,7 +9,6 @@ links:
   - >-
     [The component
     lifecycle](https://facebook.github.io/react/docs/react-component.html#the-component-lifecycle){website}
-parent: function-components
 ---
 
 # The component lifecycle

--- a/react/introduction/basics-ii/react-conditional-rendering-part-1.md
+++ b/react/introduction/basics-ii/react-conditional-rendering-part-1.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Conditional
     rendering](https://facebook.github.io/react/docs/conditional-rendering.html){website}
-parent: event-handling-in-react
 ---
 
 # Conditional rendering (Part 1)

--- a/react/introduction/basics-ii/react-conditional-rendering-part-2.md
+++ b/react/introduction/basics-ii/react-conditional-rendering-part-2.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Conditional
     rendering](https://facebook.github.io/react/docs/conditional-rendering.html){website}
-parent: conditional-rendering-part-1
 ---
 
 # Conditional Rendering (Part 2)

--- a/react/introduction/basics-ii/react-destructuring-arguments.md
+++ b/react/introduction/basics-ii/react-destructuring-arguments.md
@@ -9,7 +9,6 @@ links:
   - >-
     [Destructuring objects as function
     parameters](https://simonsmith.io/destructuring-objects-as-function-parameters-in-es6/){website}
-parent: jsx-spread-attributes
 ---
 
 # Destructuring arguments

--- a/react/introduction/basics-ii/react-jsx-spread-attributes.md
+++ b/react/introduction/basics-ii/react-jsx-spread-attributes.md
@@ -6,7 +6,6 @@ links:
   - >-
     [JSX spread
     attributes](https://gist.github.com/sebmarkbage/07bbe37bc42b6d4aef81){website}
-parent: the-ref-callback-attribute
 ---
 
 # JSX Spread attributes

--- a/react/introduction/basics-ii/react-the-ref-callback-attribute.md
+++ b/react/introduction/basics-ii/react-the-ref-callback-attribute.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Refs and the
     DOM](https://facebook.github.io/react/docs/refs-and-the-dom.html){website}
-parent: conditional-rendering-part-2
 ---
 
 # The `ref` callback attribute

--- a/react/introduction/intro-react/react-intro-components.md
+++ b/react/introduction/intro-react/react-intro-components.md
@@ -6,7 +6,6 @@ links:
   - >-
     [React Getting
     Started](https://facebook.github.io/react/docs/getting-started.html){website}
-parent: why-use-react
 ---
 
 # Intro Components

--- a/react/introduction/intro-react/react-what-i-need-to-use-react.md
+++ b/react/introduction/intro-react/react-what-i-need-to-use-react.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Getting
     Started](https://facebook.github.io/react/docs/getting-started.html){website}
-parent: why-use-react
 ---
 
 # React Dependencies

--- a/react/introduction/intro-react/react-what-is-jsx.md
+++ b/react/introduction/intro-react/react-what-is-jsx.md
@@ -9,7 +9,6 @@ links:
   - >-
     [JSX looks like an
     abomination](https://medium.com/javascript-scene/jsx-looks-like-an-abomination-1c1ec351a918#.amqkpfybp/){website}
-parent: what-is-react
 ---
 
 # What is JSX?

--- a/react/introduction/intro-react/react-why-use-react.md
+++ b/react/introduction/intro-react/react-why-use-react.md
@@ -9,7 +9,6 @@ links:
   - >-
     [What is
     React.js](https://www.linkedin.com/pulse/what-reactjs-why-i-recommend-other-javascript-sandip-das){website}
-parent: one-way-data-binding
 ---
 
 # Why use React?

--- a/react/tips/good-to-know/react-fragments-in-react.md
+++ b/react/tips/good-to-know/react-fragments-in-react.md
@@ -4,7 +4,6 @@ type: normal
 category: feature
 links:
   - '[Fragments](https://facebook.github.io/react/docs/fragments.html){website}'
-parent: custom-proptype-s-to-be-required
 ---
 
 # Fragments in **React**

--- a/react/tips/good-to-know/react-immutability-helpers-in-react.md
+++ b/react/tips/good-to-know/react-immutability-helpers-in-react.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Immutability
     Helper](https://github.com/kolodny/immutability-helper){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Immutability helpers in React

--- a/react/tips/good-to-know/react-load-initial-data-via-ajax.md
+++ b/react/tips/good-to-know/react-load-initial-data-via-ajax.md
@@ -4,7 +4,6 @@ type: normal
 category: must-know
 links:
   - '[Ajax FAQ](https://facebook.github.io/react/docs/faq-ajax.html){website}'
-parent: custom-proptype-s-to-be-required
 ---
 
 # Load Initial Data via AJAX

--- a/react/tips/good-to-know/react-null-value-for-controlled-components-in-react.md
+++ b/react/tips/good-to-know/react-null-value-for-controlled-components-in-react.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: best practice
-parent: custom-proptype-s-to-be-required
 ---
 
 # `null` value for Controlled Components in React

--- a/react/tips/good-to-know/react-reactdom-render-ref.md
+++ b/react/tips/good-to-know/react-reactdom-render-ref.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Refs and the
     DOM](https://facebook.github.io/react/docs/refs-and-the-dom.html){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # `React.createRef`

--- a/react/tips/gotchas/react-dangerously-set-innerhtml.md
+++ b/react/tips/gotchas/react-dangerously-set-innerhtml.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Official
     Documentation](https://facebook.github.io/react/docs/dom-elements.html#dangerouslysetinnerhtml){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # Dangerously set `innerHTML`

--- a/react/tips/gotchas/react-if-else-statements-in-jsx-and-react.md
+++ b/react/tips/gotchas/react-if-else-statements-in-jsx-and-react.md
@@ -6,7 +6,6 @@ links:
   - >-
     [Inline if else conditional
     operator](https://facebook.github.io/react/docs/conditional-rendering.html#inline-if-else-with-conditional-operator){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # if/else statements in JSX and React

--- a/react/tips/gotchas/react-react-in-line-styles.md
+++ b/react/tips/gotchas/react-react-in-line-styles.md
@@ -5,7 +5,6 @@ category: must-know
 links:
   - >-
     [Style](https://facebook.github.io/react/docs/dom-elements.html#style){website}
-parent: custom-proptype-s-to-be-required
 ---
 
 # React in-line styles

--- a/react/tips/gotchas/react-self-closing-tags-in-jsx.md
+++ b/react/tips/gotchas/react-self-closing-tags-in-jsx.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: must-know
-parent: custom-proptype-s-to-be-required
 ---
 
 # Self-closing tags in JSX

--- a/react/tips/gotchas/react-using-false-in-jsx.md
+++ b/react/tips/gotchas/react-using-false-in-jsx.md
@@ -2,7 +2,6 @@
 author: catalin
 type: normal
 category: best practice
-parent: custom-proptype-s-to-be-required
 ---
 
 # Using `false` in JSX

--- a/security/appsec/osi-ii/identifying-the-data-link-layer.md
+++ b/security/appsec/osi-ii/identifying-the-data-link-layer.md
@@ -7,7 +7,6 @@ links:
   - >-
     [SANS
     Institute](https://www.sans.org/reading-room/whitepapers/protocols/applying-osi-layer-network-model-information-security-1309){website}
-parent: securing-the-physical-layer
 ---
 
 # Identifying the Data Link Layer

--- a/security/appsec/osi-ii/identifying-the-presentation-layer.md
+++ b/security/appsec/osi-ii/identifying-the-presentation-layer.md
@@ -7,7 +7,6 @@ links:
   - >-
     [SANS
     Institute](https://www.sans.org/reading-room/whitepapers/protocols/applying-osi-layer-network-model-information-security-1309){website}
-parent: securing-the-session-layer
 ---
 
 # Identifying the Presentation Layer

--- a/security/appsec/osi-ii/identifying-the-session-layer.md
+++ b/security/appsec/osi-ii/identifying-the-session-layer.md
@@ -7,7 +7,6 @@ links:
   - >-
     [SANS
     Institute](https://www.sans.org/reading-room/whitepapers/protocols/applying-osi-layer-network-model-information-security-1309){website}
-parent: securing-the-transport-layer
 ---
 
 # Identifying the Session Layer

--- a/security/appsec/osi-ii/identifying-the-transport-layer.md
+++ b/security/appsec/osi-ii/identifying-the-transport-layer.md
@@ -7,7 +7,6 @@ links:
   - >-
     [SANS
     Institute](https://www.sans.org/reading-room/whitepapers/protocols/applying-osi-layer-network-model-information-security-1309){website}
-parent: securing-the-network-layer
 ---
 
 # Identifying the Transport Layer

--- a/security/appsec/osi-intro/identifying-the-network-layer.md
+++ b/security/appsec/osi-intro/identifying-the-network-layer.md
@@ -11,8 +11,6 @@ links:
     [SANS
     Institute](https://www.sans.org/reading-room/whitepapers/protocols/applying-osi-layer-network-model-information-security-1309){website}
 
-parent: securing-the-data-link-layer
-
 ---
 
 # Identifying the Network Layer

--- a/security/appsec/osi-intro/identifying-the-physical-layer.md
+++ b/security/appsec/osi-intro/identifying-the-physical-layer.md
@@ -10,8 +10,6 @@ links:
     [SANS
     Institute](https://www.sans.org/reading-room/whitepapers/protocols/applying-osi-layer-network-model-information-security-1309){website}
 
-parent: introducing-the-osi-model
-
 ---
 
 # Identifying the Physical Layer

--- a/sql/ddl/alter/add-column.md
+++ b/sql/ddl/alter/add-column.md
@@ -10,7 +10,6 @@ links:
   - >-
     [More on ALTER
     TABLE](https://www.techonthenet.com/sql_server/tables/alter_table.php){website}
-parent: create-a-table
 ---
 
 # Add Column

--- a/sql/ddl/indices/create-indexes.md
+++ b/sql/ddl/indices/create-indexes.md
@@ -22,7 +22,6 @@ links:
   - >-
     [Create Index
     W3Schools](https://www.w3schools.com/sql/sql_create_index.asp){website}
-parent: add-rule
 ---
 
 # Create Indices

--- a/sql/dql/aggregate-queries/group-by-clause.md
+++ b/sql/dql/aggregate-queries/group-by-clause.md
@@ -9,7 +9,6 @@ links:
   - >-
     [More on GROUP
     BY](https://www.techonthenet.com/sql/group_by.php){documentation}
-parent: order-by-clause
 ---
 
 # Group By clause

--- a/sql/dql/joins/inner-join.md
+++ b/sql/dql/joins/inner-join.md
@@ -12,8 +12,6 @@ tags:
 links:
   - '[Inner Join](https://en.wikipedia.org/wiki/Join_(SQL)#Inner_join){website}'
 
-parent: avg-clause
-
 ---
 
 # INNER JOIN

--- a/web/html/best-practices/README.md
+++ b/web/html/best-practices/README.md
@@ -1,8 +1,11 @@
 name: Best Practices
+
 type: insights-list
+
 description: Learn how to write the *best* HTML code.
+
 section: 0
-parent: html-versions
+
 insights:
   - doctype-always-first
   - html-vs-htm
@@ -11,9 +14,9 @@ insights:
   - quote-attribute-values
   - alt-with-images
   - conditional-comments-ie9
+
 aspects:
   - introduction
   - workout
   - deep
   - obscura
- 

--- a/web/html/computer-code/README.md
+++ b/web/html/computer-code/README.md
@@ -1,18 +1,22 @@
 name: Computer Code
+
 type: insights-list
+
 description: Displaying code in your HTML website.
+
 section: 0
-parent: formatting-text-elements
+
 insights:
   - intro-code
   - intro-kbd
   - intro-samp
   - intro-pre
   - intro-var
+
 exercises:
   - html-computer-code-codepen-exercise
+
 aspects:
   - introduction
   - workout
   - deep
- 

--- a/web/html/core-html-elements/README.md
+++ b/web/html/core-html-elements/README.md
@@ -1,18 +1,22 @@
 name: Core HTML Elements
+
 type: insights-list
+
 description: Learn about some of the widely used HTML elements.
+
 section: 0
-parent: meta-elements
+
 insights:
   - paragraphs
   - headings-h1-h6
   - update-images
   - update-hyperlinks
   - style-element
+
 exercises:
   - html-headings-and-paragraphs-codepen-exercise
   - html-create-link-codepen-exercise
   - html-add-image-codepen-exercise
+
 aspects:
   - introduction
- 

--- a/web/html/html-structure/README.md
+++ b/web/html/html-structure/README.md
@@ -1,17 +1,21 @@
 name: HTML Structure
+
 type: insights-list
+
 description: How to write HTML code.
+
 section: 0
-parent: web-introduction
+
 insights:
   - html-structure-define
   - elements
   - html-tags
   - attributes
   - comments
+
 exercises:
   - html-comment-codepen-exercise
   - html-element-attribute-codepen-exercise
+
 aspects:
   - introduction
- 

--- a/web/html/web-page-structure/README.md
+++ b/web/html/web-page-structure/README.md
@@ -1,13 +1,16 @@
 name: Web Page Structure
+
 type: insights-list
+
 description: Learn how an HTML webpage is structured.
+
 section: 0
-parent: html-structure
+
 insights:
   - doctype
   - html-element
   - head-element
   - optional-elements
+
 aspects:
   - introduction
- 

--- a/web/styling/dimensioning-and-box-sizing/inherit-box-sizing.md
+++ b/web/styling/dimensioning-and-box-sizing/inherit-box-sizing.md
@@ -7,7 +7,6 @@ links:
   - >-
     [MDN Docs on Box
     Sizing](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing){documentation}
-parent: use-box-sizing-to-define-an-element-s-width-and-height-properties
 ---
 
 # Inherit `box-sizing`

--- a/web/styling/responsive-design-tips/responsive-images-in-a-layout.md
+++ b/web/styling/responsive-design-tips/responsive-images-in-a-layout.md
@@ -13,7 +13,6 @@ links:
   - >-
     [Web Design
     Basics](https://developers.google.com/web/fundamentals/layouts/rwd-fundamentals/use-media-queries?hl=en){website}
-parent: using-media-rule-to-create-cross-platform-responsiveness
 ---
 
 # Responsive images in a layout

--- a/web/styling/typography/change-the-color-of-the-decoration-with-text-decoration-color.md
+++ b/web/styling/typography/change-the-color-of-the-decoration-with-text-decoration-color.md
@@ -9,7 +9,6 @@ links:
   - >-
     [More Control Over Text
     Decoration](https://css-tricks.com/more-control-over-text-decoration/){website}
-parent: underline-feature-on-html-elements
 ---
 
 # Change the color of the decoration with `text-decoration-color`


### PR DESCRIPTION
the `parent` field inside an insight or a workout's README is not used anymore, so it can be removed