### PR TITLE
Update the-not-operator.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ Types of change:
 
 ### Fixed
 
+## December 18th 2020
+
+### Changed
+- [Python - not and is operator - Move mention of `is` operator from the `not` insight to the `is operator` insight](https://github.com/enkidevs/curriculum/pull/2507)
+
 ## December 17th 2020
 
 ## Changed

--- a/python/python-core/control-flow-ii/the-not-operator.md
+++ b/python/python-core/control-flow-ii/the-not-operator.md
@@ -30,8 +30,7 @@ not (x < y)
 # False
 ```
 
-You can also negate the `in` and `is` operators to check whether a value is `not in` another object, or to check whether an instance `is not` identical to another instance. 
-
+You can also negate the `in` operator to check whether a value is `not in` another object.
 
 ---
 

--- a/python/python-core/memory-allocation/the-is-operator.md
+++ b/python/python-core/memory-allocation/the-is-operator.md
@@ -83,6 +83,8 @@ print(hex(id(y)))
 # '0x7faef0fc9dc0'
 ```
 
+You can also negate the `is` operator to check whether an instance `is not` identical to another instance.
+
 ---
 
 ## Practice


### PR DESCRIPTION
Remove the mention of the `is` operators as the `is` operator insight is further down the topic

Add removed information about `is` to the `is operator insight`