### PR TITLE
Add type in the gap to python functional programming 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ Types of change:
 
 ### Fixed
 
+## February 2nd 2021
+
+### Added
+
+- [Python - Functional Programming Topic - Add type in the gap questions and change format](https://github.com/enkidevs/curriculum/pull/2587)
+
 ## February 1st 2021
 
 ### Changed

--- a/python/functional-programming/arrays-i/the-all-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-all-built-in-function.md
@@ -9,23 +9,21 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 
-# The `all` Built-in Function
+# The all Function
 
 
 ---
 
 ## Content
 
-The `all` function takes an iterable object and returns `True` if all the elements in the iterable object evaluate to `True`, or if the object is empty. It takes the form:
+The `all` built-in function takes an iterable object and returns `True` if all the elements in the iterable object evaluate to `True`, or if the object is empty. It takes the form:
 
 ```python
 all(iterable)

--- a/python/functional-programming/arrays-i/the-all-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-all-built-in-function.md
@@ -9,11 +9,13 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # The `all` Built-in Function

--- a/python/functional-programming/arrays-i/the-reversed-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-reversed-built-in-function.md
@@ -9,11 +9,13 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # The `reversed` Built-in Function

--- a/python/functional-programming/arrays-i/the-reversed-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-reversed-built-in-function.md
@@ -18,7 +18,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `reversed` Built-in Function
+# The reversed Function
 
 
 ---

--- a/python/functional-programming/arrays-i/the-slice-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-slice-built-in-function.md
@@ -9,11 +9,13 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # The `slice` Built-in Function

--- a/python/functional-programming/arrays-i/the-slice-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-slice-built-in-function.md
@@ -18,7 +18,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `slice` Built-in Function
+# The slice Function
 
 
 ---

--- a/python/functional-programming/arrays-i/the-sum-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-sum-built-in-function.md
@@ -16,14 +16,14 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `sum` Built-in Function
+# The sum Function
 
 
 ---
 
 ## Content
 
-`sum` allows us to find the total of a iterable collection of numbers. It takes the general form:
+The `sum` built-in allows us to find the total of a iterable collection of numbers. It takes the general form:
 
 ```python
 sum(iterable [, start])

--- a/python/functional-programming/arrays-i/the-sum-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-sum-built-in-function.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `sum` Built-in Function

--- a/python/functional-programming/arrays-i/the-zip-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-zip-built-in-function.md
@@ -12,6 +12,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
+    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:
@@ -19,7 +20,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `zip` Built-in Function
+# The zip Function
 
 
 ---

--- a/python/functional-programming/arrays-i/the-zip-built-in-function.md
+++ b/python/functional-programming/arrays-i/the-zip-built-in-function.md
@@ -12,11 +12,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `zip` Built-in Function

--- a/python/functional-programming/arrays-ii/the-filter-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-filter-built-in-function.md
@@ -15,11 +15,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `filter` Built-in Function

--- a/python/functional-programming/arrays-ii/the-filter-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-filter-built-in-function.md
@@ -22,7 +22,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `filter` Built-in Function
+# The filter Function
 
 
 ---

--- a/python/functional-programming/arrays-ii/the-map-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-map-built-in-function.md
@@ -15,11 +15,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `map` Built-in Function

--- a/python/functional-programming/arrays-ii/the-map-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-map-built-in-function.md
@@ -22,7 +22,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `map` Built-in Function
+# The map Function
 
 
 ---

--- a/python/functional-programming/arrays-ii/the-max-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-max-built-in-function.md
@@ -19,14 +19,14 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `max` Built-in Function
+# The max Function
 
 
 ---
 
 ## Content
 
-The `max` function returns the largest item in an iterable object, or, the largest of two or more parameters given to it. The general syntax follows the form:
+The `max` built-in function returns the largest item in an iterable object, or, the largest of two or more parameters given to it. The general syntax follows the form:
 
 ```python
 max(iterable, *iterables [,key, default])

--- a/python/functional-programming/arrays-ii/the-max-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-max-built-in-function.md
@@ -12,11 +12,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `max` Built-in Function

--- a/python/functional-programming/arrays-ii/the-reduce-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-reduce-built-in-function.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `reduce` Built-in Function

--- a/python/functional-programming/arrays-ii/the-reduce-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-reduce-built-in-function.md
@@ -16,7 +16,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `reduce` Built-in Function
+# The reduce Function
 
 
 ---

--- a/python/functional-programming/arrays-ii/the-sorted-built-in-function-ii.md
+++ b/python/functional-programming/arrays-ii/the-sorted-built-in-function-ii.md
@@ -18,7 +18,7 @@ practiceQuestion:
   context: standalone
 ---
 
-# The `sorted` Built-in Function (Part 2)
+# The sorted Function (Part 2)
 
 
 ---

--- a/python/functional-programming/arrays-ii/the-sorted-built-in-function-ii.md
+++ b/python/functional-programming/arrays-ii/the-sorted-built-in-function-ii.md
@@ -15,7 +15,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `sorted` Built-in Function (Part 2)

--- a/python/functional-programming/arrays-ii/the-sorted-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-sorted-built-in-function.md
@@ -22,7 +22,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# The `sorted` Built-in Function (Part 1)
+# The sorted Function 
 
 
 ---

--- a/python/functional-programming/arrays-ii/the-sorted-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-sorted-built-in-function.md
@@ -15,11 +15,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # The `sorted` Built-in Function (Part 1)

--- a/python/functional-programming/comprehension/list-comprehension.md
+++ b/python/functional-programming/comprehension/list-comprehension.md
@@ -13,7 +13,6 @@ practiceQuestion:
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 

--- a/python/functional-programming/comprehension/list-comprehension.md
+++ b/python/functional-programming/comprehension/list-comprehension.md
@@ -8,11 +8,13 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # List comprehension

--- a/python/functional-programming/comprehension/nested-lists-comprehension.md
+++ b/python/functional-programming/comprehension/nested-lists-comprehension.md
@@ -8,11 +8,12 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # Nested lists comprehension

--- a/python/functional-programming/comprehension/nested-lists-comprehension.md
+++ b/python/functional-programming/comprehension/nested-lists-comprehension.md
@@ -12,7 +12,6 @@ practiceQuestion:
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 
@@ -90,7 +89,6 @@ l = [??? for x in range(10)\
 What will the output of the following snippet be?
 
 ```python
-
 l = [(x, y) for x in range(10) if x % 2 /
     for y in range(10) if y % 2 == 0]
 print(l[2])

--- a/python/functional-programming/comprehension/set-comprehension.md
+++ b/python/functional-programming/comprehension/set-comprehension.md
@@ -11,11 +11,11 @@ notes: >-
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Set comprehension

--- a/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
+++ b/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
@@ -19,7 +19,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# Speed up your `for` loop using `map()` or list comprehensions
+# Speed up your for loop using map() or list comprehensions
 
 
 ---

--- a/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
+++ b/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
@@ -11,11 +11,12 @@ notes: ''
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Speed up your `for` loop using `map()` or list comprehensions

--- a/python/functional-programming/decorators/decorators-methods.md
+++ b/python/functional-programming/decorators/decorators-methods.md
@@ -101,7 +101,9 @@ def deco(func):
     ...
 ```
 
+```plain-text
 ???
+```
 
 - A
 - B
@@ -133,7 +135,9 @@ def deco(self):
   return wrapper
 ```
 
+```plain-text
 ???
+```
 
 - B
 - C

--- a/python/functional-programming/decorators/decorators-methods.md
+++ b/python/functional-programming/decorators/decorators-methods.md
@@ -5,11 +5,13 @@ category: must-know
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # Decorators and methods

--- a/python/functional-programming/decorators/decorators-syntax.md
+++ b/python/functional-programming/decorators/decorators-syntax.md
@@ -5,11 +5,13 @@ category: feature
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # Decorators syntax

--- a/python/functional-programming/decorators/functools-wraps.md
+++ b/python/functional-programming/decorators/functools-wraps.md
@@ -12,7 +12,7 @@ revisionQuestion:
   context: standalone
 ---
 
-# Functools' `wraps`
+# Functools' wraps
 
 
 ---

--- a/python/functional-programming/decorators/functools-wraps.md
+++ b/python/functional-programming/decorators/functools-wraps.md
@@ -5,11 +5,11 @@ category: feature
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Functools' `wraps`

--- a/python/functional-programming/decorators/what-are-decorators.md
+++ b/python/functional-programming/decorators/what-are-decorators.md
@@ -118,7 +118,9 @@ def hello_heading(func):
   return func_wrapper
 ```
 
+```plain-text
 ???
+```
 
 - B
 - A

--- a/python/functional-programming/decorators/what-are-decorators.md
+++ b/python/functional-programming/decorators/what-are-decorators.md
@@ -9,11 +9,12 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # What Are Decorators?

--- a/python/functional-programming/decorators/what-is-a-closure.md
+++ b/python/functional-programming/decorators/what-is-a-closure.md
@@ -86,7 +86,9 @@ def foo():
     print(myname)
 ```
 
+```plain-text
 ???
+```
 
 - C
 - A

--- a/python/functional-programming/decorators/what-is-a-closure.md
+++ b/python/functional-programming/decorators/what-is-a-closure.md
@@ -10,11 +10,12 @@ notes: 'prerequisites: scoping'
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # What Are Higher-Order Functions?

--- a/python/functional-programming/functional-programming-ii/functional-particularities-of-python.md
+++ b/python/functional-programming/functional-programming-ii/functional-particularities-of-python.md
@@ -71,7 +71,9 @@ Finally, Python is also lucky to have an avid user base which is constantly prov
 
 What keyword makes a function a generator?
 
+```python
 ???
+```
 
 - `yield`
 - `return`

--- a/python/functional-programming/functional-programming-ii/functional-particularities-of-python.md
+++ b/python/functional-programming/functional-programming-ii/functional-particularities-of-python.md
@@ -9,11 +9,12 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Functional Particularities of Python

--- a/python/functional-programming/functional-programming-ii/functional-particularities-of-python.md
+++ b/python/functional-programming/functional-programming-ii/functional-particularities-of-python.md
@@ -5,7 +5,7 @@ category: must-know
 links:
   - >-
     [Functional Programming in
-    Python](http://www.oreilly.com/programming/free/files/functional-programming-python.pdf){website}
+    Python](https://ia801304.us.archive.org/20/items/functional-programming-python/functional-programming-python.pdf){website}
 practiceQuestion:
   formats:
     - fill-in-the-gap

--- a/python/functional-programming/functional-programming-ii/functions-vs-procedures.md
+++ b/python/functional-programming/functional-programming-ii/functions-vs-procedures.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Functions vs procedures

--- a/python/functional-programming/functional-programming-ii/is-python-functional-language.md
+++ b/python/functional-programming/functional-programming-ii/is-python-functional-language.md
@@ -5,7 +5,7 @@ category: must-know
 links:
   - >-
     [Is Python a functional
-    language?](https://www.quora.com/Is-Python-a-functional-language){website}
+    language?](https://stackabuse.com/functional-programming-in-python/#:~:text=Python%20is%20not%20a%20functional,for%20the%20task%20at%20hand.){website}
 practiceQuestion:
   formats:
     - fill-in-the-gap

--- a/python/functional-programming/functional-programming-ii/is-python-functional-language.md
+++ b/python/functional-programming/functional-programming-ii/is-python-functional-language.md
@@ -9,7 +9,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Is Python a Functional Language?

--- a/python/functional-programming/functional-programming-ii/lambda-functions.md
+++ b/python/functional-programming/functional-programming-ii/lambda-functions.md
@@ -5,11 +5,12 @@ category: tip
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # `Lambda` Functions

--- a/python/functional-programming/functional-programming/what-is-functional-programming.md
+++ b/python/functional-programming/functional-programming/what-is-functional-programming.md
@@ -9,11 +9,12 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # What is functional programming

--- a/python/functional-programming/functional-programming/what-is-functional-programming.md
+++ b/python/functional-programming/functional-programming/what-is-functional-programming.md
@@ -9,6 +9,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
+    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:
@@ -102,7 +103,7 @@ result = ???(sum(2, 3),4)
 
 ## Revision
 
-Can you predict the output?
+Can you predict what the output will be?
 
 ```py
 foo = list(range(1,10))
@@ -116,11 +117,13 @@ print(result)
 
 ```
 
-???
+```plain-text
+[???]
+```
 
-- [2]
-- [2, 4, 6, 8]
-- [2, 4, 6, 8, 10]
+- 2
+- 2, 4, 6, 8
+- 2, 4, 6, 8, 10
 
 
 ---

--- a/python/functional-programming/functional-programming/why-functional-programming-ii.md
+++ b/python/functional-programming/functional-programming/why-functional-programming-ii.md
@@ -12,7 +12,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Eschewing Shared State

--- a/python/functional-programming/functional-programming/why-functional-programming-iii.md
+++ b/python/functional-programming/functional-programming/why-functional-programming-iii.md
@@ -12,7 +12,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Using Immutable Data

--- a/python/functional-programming/functional-programming/why-functional-programming.md
+++ b/python/functional-programming/functional-programming/why-functional-programming.md
@@ -12,11 +12,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Why Functional Programming?

--- a/python/functional-programming/generators/benefits-of-using-generators.md
+++ b/python/functional-programming/generators/benefits-of-using-generators.md
@@ -16,11 +16,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Benefits of Using Generators

--- a/python/functional-programming/generators/generator-of-generators.md
+++ b/python/functional-programming/generators/generator-of-generators.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Generator of generators
@@ -63,7 +63,7 @@ Finally, we print a list containing the first 10 *elements* of the *Fibonacci se
 
 We want to generate the first `n` perfect squares. Fill the gaps accordingly:
 
-```plain-text
+```python
 def perfect_square():
   x = 1
   while ???:
@@ -89,7 +89,7 @@ def first_n(g,n):
 
 What will the output be?
 
-```plain-text
+```python
 def power_of_two():
     x = 2
     while True:

--- a/python/functional-programming/generators/recursive-generator.md
+++ b/python/functional-programming/generators/recursive-generator.md
@@ -62,7 +62,6 @@ One common use of **recursive generators** is traversing *non-linear data struct
 ## Practice
 
 Can you spot which of the following generators are recursive?
-???
 
 ```python
 def list_gen(l):
@@ -74,6 +73,10 @@ def cubic_generator(n):
 	for i in range(n):
 		yield i ** 3
 
+```
+
+```plain-text
+???
 ```
 
 - `list_gen`

--- a/python/functional-programming/generators/recursive-generator.md
+++ b/python/functional-programming/generators/recursive-generator.md
@@ -9,11 +9,13 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # Recursive generator
@@ -27,7 +29,7 @@ Before the release of Python 3, **recursive generators** were implemented by cal
 
 Consider the following example:
 
-```plain-text
+```python
 def infinity(start):
     yield start
     for x in infinity(start + 1)
@@ -40,7 +42,7 @@ To achieve the same result, **Python 3** introduced a new construct, called `yie
 
 Let's check out the example above implemented using `yield from`:
 
-```plain-text
+```python
 def infinity(start):
     yield start
     yield from infinity(start + 1)
@@ -62,7 +64,7 @@ One common use of **recursive generators** is traversing *non-linear data struct
 Can you spot which of the following generators are recursive?
 ???
 
-```plain-text
+```python
 def list_gen(l):
     if l:
         yield l[0]
@@ -86,7 +88,7 @@ def cubic_generator(n):
 
 Complete the missing Python 3 specific syntax of the following recursive generator:
 
-```plain-text
+```python
 def countdown(start):
     yield ???
     ??? ??? ???(start - 1)

--- a/python/functional-programming/generators/what-are-generators.md
+++ b/python/functional-programming/generators/what-are-generators.md
@@ -15,7 +15,8 @@ notes: >-
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # What are generators

--- a/python/functional-programming/generators/what-are-generators.md
+++ b/python/functional-programming/generators/what-are-generators.md
@@ -58,9 +58,11 @@ print(next(g)) # StopIteration error
 
 ## Revision
 
-What statement is specific to generators instead of `return` ?
+What other statement is specific to generators instead of `return`?
 
+```python
 ???
+```
 
 - `yield`
 - `for`

--- a/python/functional-programming/generators/yield-and-next.md
+++ b/python/functional-programming/generators/yield-and-next.md
@@ -10,6 +10,7 @@ practiceQuestion:
 revisionQuestion:
   formats:
     - fill-in-the-gap
+    - type-in-the-gap
   context: standalone
 ---
 
@@ -78,10 +79,11 @@ def countdown(num):
 
 >>> gen = countdown(5)
 >>> print(next(gen))
-
 ```
 
+```plain-text
 ???
+```
 
 - `5`
 - `0`

--- a/python/functional-programming/generators/yield-and-next.md
+++ b/python/functional-programming/generators/yield-and-next.md
@@ -5,11 +5,12 @@ category: must-know
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # yield() and next()

--- a/python/functional-programming/iterators/iterators-applications.md
+++ b/python/functional-programming/iterators/iterators-applications.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Iterators Applications

--- a/python/functional-programming/iterators/the-iteration-protocol.md
+++ b/python/functional-programming/iterators/the-iteration-protocol.md
@@ -104,7 +104,9 @@ print(sum(iterator))
 print(sum(iterator))
 ```
 
+```plain-text
 ???, then ???
+```
 
 - 15
 - 0

--- a/python/functional-programming/iterators/the-iteration-protocol.md
+++ b/python/functional-programming/iterators/the-iteration-protocol.md
@@ -9,11 +9,12 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # The Iteration Protocol
@@ -103,13 +104,13 @@ print(sum(iterator))
 print(sum(iterator))
 ```
 
-???
+???, then ???
 
-- 15, then 0
+- 15
+- 0
 - TypeError exception
-- 15, then 15
-- 5, then 5
-- 5, then 0
+- 10
+- 5
 
 
 ---

--- a/python/functional-programming/iterators/the-itertools-module-ii.md
+++ b/python/functional-programming/iterators/the-itertools-module-ii.md
@@ -12,11 +12,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # chain(), filterfalse() and compress()

--- a/python/functional-programming/iterators/the-itertools-module.md
+++ b/python/functional-programming/iterators/the-itertools-module.md
@@ -12,7 +12,8 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # The `itertools` Module

--- a/python/functional-programming/iterators/the-itertools-module.md
+++ b/python/functional-programming/iterators/the-itertools-module.md
@@ -16,7 +16,7 @@ practiceQuestion:
   context: standalone
 ---
 
-# The `itertools` Module
+# The itertools Module
 
 
 ---

--- a/python/functional-programming/iterators/what-are-iterators.md
+++ b/python/functional-programming/iterators/what-are-iterators.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # What Are Iterators?

--- a/python/functional-programming/iterators/what-is-an-iterable.md
+++ b/python/functional-programming/iterators/what-is-an-iterable.md
@@ -18,11 +18,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # What Is an Iterable?

--- a/python/functional-programming/python-immutability/atomicity-of-failure.md
+++ b/python/functional-programming/python-immutability/atomicity-of-failure.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Atomicity of Failure

--- a/python/functional-programming/python-immutability/avoiding-identity-mutation.md
+++ b/python/functional-programming/python-immutability/avoiding-identity-mutation.md
@@ -9,7 +9,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Avoiding Identity Mutation

--- a/python/functional-programming/python-immutability/distinguish-the-mutability-of-common-types.md
+++ b/python/functional-programming/python-immutability/distinguish-the-mutability-of-common-types.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Distinguish the Mutability of Common Types

--- a/python/functional-programming/python-immutability/immutability-gotchas.md
+++ b/python/functional-programming/python-immutability/immutability-gotchas.md
@@ -9,11 +9,11 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Immutability Gotchas!

--- a/python/functional-programming/python-immutability/what-is-immutability.md
+++ b/python/functional-programming/python-immutability/what-is-immutability.md
@@ -9,11 +9,12 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # What Is Immutability?

--- a/python/functional-programming/python-immutability/what-is-immutability.md
+++ b/python/functional-programming/python-immutability/what-is-immutability.md
@@ -10,7 +10,7 @@ practiceQuestion:
   formats:
     - fill-in-the-gap
     - type-in-the-gap
-  context: standalone
+  context: relative
 revisionQuestion:
   formats:
     - fill-in-the-gap

--- a/python/functional-programming/python-immutability/why-types-have-immutability-ii.md
+++ b/python/functional-programming/python-immutability/why-types-have-immutability-ii.md
@@ -12,7 +12,7 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+  context: standalone
 ---
 
 # Prevention of Side Effects

--- a/python/functional-programming/python-immutability/why-types-have-immutability.md
+++ b/python/functional-programming/python-immutability/why-types-have-immutability.md
@@ -66,8 +66,9 @@ Which of the following is not a benefit of using immutable objects?
 7. Fewer lines of code to write
 8. Prevention of `None` references
 
+```plain-text
 ???
-
+```
 - 7
 - 1
 - 2

--- a/python/functional-programming/python-immutability/why-types-have-immutability.md
+++ b/python/functional-programming/python-immutability/why-types-have-immutability.md
@@ -12,7 +12,8 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-  context: relative
+    - type-in-the-gap
+  context: standalone
 ---
 
 # Why Types Have Immutability


### PR DESCRIPTION
Marked if applied to all insights:

- [x] Shorten all Headlines (If possible)
- [x] Remove all backticks from every headline
- [x] Add type in the gap and change context to standalone to all applicable questions
- [x] Modify questions to support type in the gap (if possible)