### PR TITLE
Update the-filter-built-in-function.md

### DIFF
--- a/python/functional-programming/arrays-ii/the-filter-built-in-function.md
+++ b/python/functional-programming/arrays-ii/the-filter-built-in-function.md
@@ -104,15 +104,26 @@ What is the printed result of the following code execution?
 numbers = [-3, -2, -1, 0, 1, 2, 3]
 def mystery_function(element):
   return element < 0
-print(filter(mystery_function, numbers))
+
+filteredElements = filter(less_than_two, prices)
+
+for num in filteredElements:
+    print(num)
+    
+# ???
+# ???
+# ???
 ```
 
 ???
 
-- `[-3, -2, -1]`
-- `[-1, -2, -3]`
-- `[1, 2, 3]`
-
+- `-3`
+- `-2`
+- `-1`
+- `3`
+- `2`
+- `1`
+- `0`
 
 ---
 


### PR DESCRIPTION
I have updated this question because when testing the code, the output was:

`<filter object at 0x0000012E54DF0EE0>`

Instead of:
`[-3,-2,-1]`

I modified the example a little bit by saving the filtered result in a new variable and then printing the filtered result using a for loop.