### PR TITLE
Update if-elif-else-statements.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## March 9th 2021
+
+### Fixed
+- [Python - If, elif, else - fix practice question and shorten headline](https://github.com/enkidevs/curriculum/pull/2635)
+
 ## March 8th 2021
 
 ### Added

--- a/python/python-core/control-flow-i/if-elif-else-statements.md
+++ b/python/python-core/control-flow-i/if-elif-else-statements.md
@@ -14,8 +14,7 @@ revisionQuestion:
   context: relative
 ---
 
-# `if...elif...else` statements
-
+# `if...elif...else` 
 
 ---
 
@@ -78,7 +77,6 @@ if days_coding == 7:
 - `=`
 - `if`
 - `<`
-- `>=`
 
 
 ---


### PR DESCRIPTION
Shorten headline. 
Here's how it looked in the app:
![headline](https://img.enkipro.com/7b09a90e80a6f8e5ef0e7f859d34c294.jpeg)

Fix broken practice question. Both `>` and `>=` are technically correct, but only one was accepted:

![incorrect](https://img.enkipro.com/c62fd78c42947999c813c5235714b653.jpeg)

![correct](https://img.enkipro.com/09eb617cda9956d2c6c59678ae47cedc.jpeg)