### PR TITLE
Update ipython-vs-shell-vs-scripts.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ Types of change:
 
 ### Changed
 - [Python Data Analysis - Why Python For Data Analysis - Remove unnecessary sentence](https://github.com/enkidevs/curriculum/pull/2636)
+- [Python Data Analysis - ipython vs shells vs scripts - Replace wordy sentences](https://github.com/enkidevs/curriculum/pull/2641)
 
 ## March 9th 2021
 

--- a/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
+++ b/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
@@ -41,6 +41,9 @@ If we save code into a file, we call that file a *script*.
 If we give the name of our file to the Python shell, we can have it execute the code for us.
 
 ```sh
+# scripts with python code
+# are usually saved with
+# the .py extension
 python my_script.py
 ```
 

--- a/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
+++ b/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
@@ -16,7 +16,7 @@ revisionQuestion:
 
 ---
 
-# IPython vs Shell vs Script
+# IPython (and Scripts)
 
 ---
 ## Content
@@ -32,19 +32,17 @@ iPython is an enhanced version of that with user-friendly features such as:
 - Syntax highlighting
 - and more
 
-The IPython shell is thus usually the recommended shell as it runs your Python code just like the normal Python shell does while also providing a richer set of features on top[1].
+The IPython shell is usually the recommended shell as it runs your Python code just like the normal Python shell does while also providing a richer set of features on top[1].
 
-### Shell vs Terminal vs Scripts
+The IPython interpreter, as well as the basic Python interpreter, are both interactive shells that are accessed through the terminal via the `python`/`ipython` commands.
 
-Shells are command-line tools used to execute code.
+If we save code into a file, we call that file a *script*.
 
-Terminals are interface sessions on the computer that we use to communicate with shells. We send input (commands) into and receive output (results) out of the shell via a terminal.
+If we give the name of our file to the Python shell, we can have it execute the code for us.
 
-The IPython interpreter, as well as the basic Python interpreter, are actually interactive shells that are accessed through the terminal via the `python`/`ipython` commands.
-
-Scripts are files with runnable code that you can use for easier execution, automation, and more. 
-
-So basically, we type code in a terminal that then sends that code to the command-line tool(shell) which then translates and executes that code for us.
+```sh
+python my_script.py
+```
 
 > 💡 Scripts are executed in the same way as regular, command-line code.
 
@@ -54,7 +52,7 @@ So basically, we type code in a terminal that then sends that code to the comman
 
 ??? are command-line tools used to execute code.
 
-??? are pieces of runnable code used for automation, easier execution, and more.
+??? are pieces of code saved into files.
 
 ??? are sessions on the computer used to communicate code to shells.
 
@@ -65,14 +63,14 @@ So basically, we type code in a terminal that then sends that code to the comman
 ---
 ## Revision
 
-When you put some runnable code in a file for easier execution, what do you call that file?
+When you put save code in a file, what do you typically call that file?
 
-A ???.
+???.
 
-- script
-- terminal
+- a script
+- a terminal
 - text
-- interpreter
+- an interpreter
 
 ---
 ## Footnotes

--- a/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
+++ b/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
@@ -21,38 +21,18 @@ revisionQuestion:
 ---
 ## Content
 
-### IPython vs Basic intepreter
+### IPython
 
 The Python language comes with a basic interpreter and a [REPL](https://www.enki.com/glossary/general/repl) that lets us write and run Python programs.
 
-iPython is an enhanced version of that with extra features that make the experience of running Python code more user-friendly.
-
-iPython features:
+iPython is an enhanced version of that with user-friendly features such as:
 - Auto-completion
 - Support for Data Visualization
 - Multi-line editing
 - Syntax highlighting
 - and more
 
-> 💡 You can also re-run any part of code you've already run with or without modification to the code.
-
-> ❗ The multi-line editing feature is not available within the iPython terminal. It is, however, available in any notebook that has iPython.
-
-Here is the same code run on the basic interpreter vs IPython:
-
-Basic interpreter:
-
-![windows-10-example](https://img.enkipro.com/cb342ec6c5fb4860fee889d907ee176b.png)
-
-IPython:
-
-![ipython-example](https://img.enkipro.com/02420b736677cad5a5d5d8bcaac54bf4.png)
-
-In the iPython example, all of the code was run on `Line [1]`. On the other hand, in the regular interpreter, we had to run five lines of code to achieve the same thing. (Not counting the two empty lines)
-
-In any terminal, pressing the ⬆️ key would give us our last executed instruction.
-
-If we press ⬆️ in iPython, it would give us the whole code as a single line. Whereas on the basic interpreter, we would have to execute the five lines one by one.
+The IPython shell is thus usually the recommended shell as it runs your Python code just like the normal Python shell does while also providing a richer set of features on top[1].
 
 ### Shell vs Terminal vs Scripts
 
@@ -93,3 +73,32 @@ A ???.
 - terminal
 - text
 - interpreter
+
+---
+## Footnotes
+[1: Multi Line Execution]
+
+Here is the same code run on the basic interpreter vs IPython:
+
+Basic interpreter:
+
+![windows-10-example](https://img.enkipro.com/cb342ec6c5fb4860fee889d907ee176b.png)
+
+IPython:
+
+![ipython-example](https://img.enkipro.com/02420b736677cad5a5d5d8bcaac54bf4.png)
+
+> 💡 In iPython, you can re-run any part of code you've already run with or without modification to the code.
+
+
+iPython lets us store multi-line code blocks behind special `Line [N]` variable names. If you look at the iPython example above, all of the code was run on `Line [1]`. This lets us split code into sections and re-run or re-use any section at any time.
+
+On the other hand, in the regular interpreter, we had to write all lines of code one by one.
+
+In any terminal, pressing the ⬆️ key would give us our last executed line.
+
+If we press ⬆️ in iPython, it would give us last executed `Line`.
+
+> ❗ The multi-line editing feature is not available within the iPython terminal and only available in notebooks (more on this to come later)
+
+You can think of notebooks as interactive Python environments that can combine code execution, rich text, charts, and rich media. 

--- a/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
+++ b/python-data-analysis/python-data-analysis-core/analysis-environments/ipython-vs-shell-vs-scripts.md
@@ -16,7 +16,7 @@ revisionQuestion:
 
 ---
 
-# IPython vs Python Shell vs Python Scripts
+# IPython vs Shell vs Script
 
 ---
 ## Content


### PR DESCRIPTION
The insight was a bit wordy so I trimmed it down.

I moved the text showcasing iPython vs Python terminals in the footnote and added a "why" explanation for the multi-line feature.

I also think we put too much emphasis on shells/scripts/terminal and done so too late. So I added some of those definitions as footnotes to the previous insight (see See also: https://github.com/enkidevs/curriculum/pull/2640) and simplified the language in this one.