### PR TITLE
Incorrect example when referring to the Physical layer

### DIFF
--- a/security/appsec/osi-intro/identifying-the-physical-layer.md
+++ b/security/appsec/osi-intro/identifying-the-physical-layer.md
@@ -31,8 +31,8 @@ The Physical Layer encompasses all electronic circuit transmission technologies 
 
 These include but are not limited to: 
 
-- switches
 - ethernet
+- network hubs
 - the USB physical layer
 - the Bluetooth physical layer
 - various wireless cards


### PR DESCRIPTION
In this article, the example of a network switch is given to represent the physical layer. This is an incorrect example.

A network switch works in the Data Link layer, due to its ability to differentiate between MAC addresses and redirect physical signals accordingly.

Ethernet hubs on the other hand, as proposed by my change, can indeed be considered as a Physical layer hardware device, since it does not know or care about MAC addresses, and all it does is replicate data to other connected devices.