### PR TITLE
Incorrect example for ARP spoofing

### DIFF
--- a/security/appsec/securing-each-layer/securing-the-data-link-layer.md
+++ b/security/appsec/securing-each-layer/securing-the-data-link-layer.md
@@ -25,7 +25,7 @@ revisionQuestion:
 
 The Data Link Layer facilitates the transfer of data around a LAN network with protocols like [ARP](https://en.wikipedia.org/wiki/Address_Resolution_Protocol). As a quick reminder, ARP is responsible for identifying and associating IP addresses of network nodes with their MAC addresses. The ARP protocol is critical for ensuring that information anywhere higher up in the OSI Model reaches the correct endpoint, and as such attracts the attention of hackers.
 
-**ARP Spoofing** involves changing a device's factory-assigned MAC address to impersonate another node on the network. Doing so tricks the ARP protocol to deliver frames to the impersonator device instead of the original sender. The impersonating device can then perform more sophisticated attacks once this identity theft is achieved, such as denial of service, man-in-the-middle attacks, or session hijacking.
+**ARP Spoofing** involves sending misleading ARP messages to impersonate another node on the network. Doing so tricks the ARP protocol to deliver frames to the impersonator device instead of the original sender. The impersonating device can then perform more sophisticated attacks once this identity theft is achieved, such as denial of service, man-in-the-middle attacks, or session hijacking.
 
 Once a hacker is inside the network MAC addresses are easy to find, and this vulnerability becomes trivial to exploit. Controls for this vulnerability include **MAC Address Filtering**: setting up a whitelist of MAC addresses that can gain access to the networks, and using Ethernet switches that integrate ARP-Spoofing detection software.
 


### PR DESCRIPTION
You cannot change a network card's MAC address. And even if you could, this doesn't involve an ARP spoofing attempt. ARP spoofing is sending "response" packets that claim the node's IP address is associated with the attacker's MAC address, thus leading to all the packets being sent to the wrong MAC address.