### PR TITLE
Go - Operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Types of change:
 ## May 11th 2021
 
 ### Fixed
-- [Go - Operators - Fix MD table]()
+- [Go - Operators - Fix MD table](https://github.com/enkidevs/curriculum/pull/2699)
 
 ## May 7th 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## May 11th 2021
+
+### Fixed
+- [Go - Operators - Fix MD table]()
+
 ## May 7th 2021
 
 ### Changed

--- a/go/go-introduction/go-operators/go-logical-operators.md
+++ b/go/go-introduction/go-operators/go-logical-operators.md
@@ -23,12 +23,9 @@ revisionQuestion:
 Just like relational operators, logical operators only evaluate to `true` or `false`.
 
 There are a total of three logical operators:
-
-| Operator | Definition                                                                     |   |                                                                        |
-| -------- | ------------------------------------------------------------------------------ | - | ---------------------------------------------------------------------- |
-| `&&`     | `AND` evaluates to `true` if all of the conditions evaluate to `true`          |   |                                                                        |
-| `        |                                                                                | ` | `OR` evaluates to `true` if at least one condition evaluates to `true` |
-| `!`      | `NOT` evaluates to `true` if the condition evaluates to `false` and vice versa |   |                                                                        |
+  * `&&` (the `AND` condition) evaluates to `true` if all of the conditions evaluate to `true` 
+  * `||` (the `OR` condition) evaluates to `true` if at least one condition evaluates to `true`
+  * `!` (the `NOT` condition) evaluates to `true` if the condition evaluates to `false` and vice versa
 
 Logical operators are commonly used in `if/if else` or `switch` statements.
 


### PR DESCRIPTION
When we added the `practiceQuestion` and `revisionQuestion` YAML fields programmatically, we also messed up this markdown table ([commit](https://github.com/enkidevs/curriculum/commit/d18c985ad2b1ebda3bc5a5880e390cc4171c76b6#diff-4557f570b11af6eb6759a7bf186a9819754b3322eca231e40c1a237bb65972a7R26))

![image](https://user-images.githubusercontent.com/19802557/117827480-ef88e080-b268-11eb-93f8-0ed425659027.png)

After toying with it for a while, I couldn't find a way to make `||` work inside the table. Unicode characters also don't work. The solution is to switch to a list:

![image](https://user-images.githubusercontent.com/19802557/117827501-f31c6780-b268-11eb-910f-73ef1003994b.png)
