### PR TITLE
Update quick-cd-tips.md

### DIFF
--- a/linux/user-and-file-management/shell/quick-cd-tips.md
+++ b/linux/user-and-file-management/shell/quick-cd-tips.md
@@ -45,7 +45,7 @@ pushd projects/
 
 After calling `pushd` followed by a folder name, the directory stack is logged in the shell and you're switched to that folder.
 
-&gt; <span class="x x-first x-last">💡 </span>Tilde `~` is a <span class="x x-first x-last">shorthand</span> notation for `Users/your-name/`.
+> 💡 Tilde `~` is a shorthand notation for `Users/your-name/`.
 
 If you want to add the current directory to the stack, you would call `pushd` while in that directory:
 


### PR DESCRIPTION
Remove weird HTML from the note.
```html
&gt; <span class="x x-first x-last">💡 </span>Tilde `~` is a <span class="x x-first x-last">shorthand</span> notation for `Users/your-name/`.
```

Replace with a normal note:
> 💡 Tilde `~` is a shorthand notation for `Users/your-name/`.


The HTML note looks like this:
![alt-info-not-provided](https://img.enkipro.com/2bd3251fcf6a2f875045d98764bfbc87.png)