### PR TITLE
Make the practice question clearer.

### DIFF
--- a/security/appsec/security-intro/automated-tools.md
+++ b/security/appsec/security-intro/automated-tools.md
@@ -43,7 +43,7 @@ In order to improve application security, we'll make use of many automated tools
 
 ## Practice
 
-In order to develop applications that cannot be scanned for vulnerabilities, you should periodically ??? your ??? using ???.
+In order to improve application security, you should periodically ??? your ??? using ???.
 
 - scan
 - application


### PR DESCRIPTION
Saying the application cannot be scanned can confuse the users of the expected outcome.