### PR TITLE
Update execute-a-command-without-saving-it-in-history.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## June 30th 2021
+
+### Fixed
+- [Linux - Execute command without saving it - fix missing space in example](https://github.com/enkidevs/curriculum/pull/2779)
+
 ## June 29th 2021
 
 ### Fixed

--- a/linux/user-and-file-management/terminal-history/execute-a-command-without-saving-it-in-history.md
+++ b/linux/user-and-file-management/terminal-history/execute-a-command-without-saving-it-in-history.md
@@ -25,14 +25,14 @@ revisionQuestion:
 
 Adding one or more spaces before your command will result in `history` not recording it.
 
-This is useful for passwords (those long mysql connections) on the command-line.
+This is useful for passwords (those long MySQL connections) on the command line.
 
 For example:
 
 ```bash
 echo 1
 1
-echo 2
+  echo 2
 2
 echo 3
 3


### PR DESCRIPTION
add missing space as that is the point of the command:
```
Adding one or more spaces before your command will result in history not recording it.

This is useful for passwords (those long mysql connections) on the command-line.
```