### PR TITLE
TypeScript - Extending Interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## August 2nd 2021
+
+### Fixed
+- [TypeScript - Extending Interfaces - Remove the type-in-the-gap from the PQ]()
+
 ## July 29th 2021
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Types of change:
 ## August 2nd 2021
 
 ### Fixed
-- [TypeScript - Extending Interfaces - Remove the type-in-the-gap from the PQ]()
+- [TypeScript - Extending Interfaces - Remove the type-in-the-gap from the PQ](https://github.com/enkidevs/curriculum/pull/2816)
 
 ## July 29th 2021
 

--- a/typescript/typescript-introduction/tsc-classes-and-interfaces/tsc-extending-interfaces.md
+++ b/typescript/typescript-introduction/tsc-classes-and-interfaces/tsc-extending-interfaces.md
@@ -12,7 +12,6 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:


### PR DESCRIPTION
- remove the type-in-the-gap from the PQ