### PR TITLE
Linux - The Basics of Command Substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ Types of change:
 ## August 17th 2021
 
 ### Fixed
-- [Linux - The Basics of Command Substitution - Remove the type-in-the-gap format from the PQ]()
+- [Linux - The Basics of Command Substitution - Remove the type-in-the-gap format from the PQ](https://github.com/enkidevs/curriculum/pull/2845)
 - [Python - Variables - Remove the type-in-the-gap format from the PQ](https://github.com/enkidevs/curriculum/pull/2843)
 - [Blockchain - Why Should You Care? - Remove the type-in-the-gap format from the RQ](https://github.com/enkidevs/curriculum/pull/2841)
 - [Blockchain - What Is a Blockchain? - Remove the type-in-the-gap format from the RQ](https://github.com/enkidevs/curriculum/pull/2840/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Types of change:
 ## August 17th 2021
 
 ### Fixed
+- [Linux - The Basics of Command Substitution - Remove the type-in-the-gap format from the PQ]()
 - [Python - Variables - Remove the type-in-the-gap format from the PQ](https://github.com/enkidevs/curriculum/pull/2843)
 - [Blockchain - Why Should You Care? - Remove the type-in-the-gap format from the RQ](https://github.com/enkidevs/curriculum/pull/2841)
 - [Blockchain - What Is a Blockchain? - Remove the type-in-the-gap format from the RQ](https://github.com/enkidevs/curriculum/pull/2840/)

--- a/linux/user-and-file-management/pipelines/the-basics-of-command-substitution.md
+++ b/linux/user-and-file-management/pipelines/the-basics-of-command-substitution.md
@@ -13,7 +13,6 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:


### PR DESCRIPTION
- remove the type-in-the-gap format from the PQ