### PR TITLE
Update throwing-an-exception.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Types of change:
 - [React - Conditional Rendering (Part 2) - Remove the type-in-the-gap format from the PQ](https://github.com/enkidevs/curriculum/pull/2839)
 - [Spreadsheets - Whole Topic - Remove any type in the gap related to formulas as upper and lowercase are both possible answers](https://github.com/enkidevs/curriculum/pull/2842)
 - [Java - Use Descriptive Error Messages When Catching Exceptions - Remove type in the gap](https://github.com/enkidevs/curriculum/pull/2844)
+- [Java - Throwing An Exception - Remove type in the gap and modify RQ so that different orders do not give wrong answers](https://github.com/enkidevs/curriculum/pull/2846)
 
 ## August 16th 2021
 

--- a/java/java-fundamentals/exceptions-i/throwing-an-exception.md
+++ b/java/java-fundamentals/exceptions-i/throwing-an-exception.md
@@ -10,7 +10,6 @@ notes: |
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 
@@ -57,9 +56,9 @@ For example, a methods that counts the number of elements from a `List` should `
 
 ## Revision
 
-The two types of exceptions are ??? and ???
+The two types of exceptions are ??? and ???.
 
-- checked
-- unchecked
-- compiled
-- runtime
+- checked & unchecked
+- compiled & runtime
+- runtime & checked
+- compiled & unchecked

--- a/java/java-fundamentals/exceptions-i/throwing-an-exception.md
+++ b/java/java-fundamentals/exceptions-i/throwing-an-exception.md
@@ -56,7 +56,7 @@ For example, a methods that counts the number of elements from a `List` should `
 
 ## Revision
 
-The two types of exceptions are ??? and ???.
+The two types of exceptions are ???.
 
 - checked & unchecked
 - compiled & runtime


### PR DESCRIPTION
Modify the revision question so that the users don't get a "wrong answer" if they answer in a different order. Also remove type in the gap as it has no benefit here