### PR TITLE
Update speed-up-your-for-loop-using-map-or-list-comprehensions.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## August 22nd 2021
+
+## Changed
+- [Python - Speed Up Your Loop Using map() or List Comprehention - Update variables to snake case and change the PQ](https://github.com/enkidevs/curriculum/pull/2853) 
+
 ## August 20th 2021
 
 ### Fixed

--- a/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
+++ b/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
@@ -34,7 +34,7 @@ If you need to lowercase all the input strings:
 
 ```python
 lower_list = []
-for word in input_listt:
+for word in input_list:
     lower_list.append(word.lower())
 ```
 

--- a/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
+++ b/python/functional-programming/comprehension/speed-up-your-for-loop-using-map-or-list-comprehensions.md
@@ -33,22 +33,22 @@ Example:
 If you need to lowercase all the input strings:
 
 ```python
-lowerList = []
-for word in inputList:
-    lowerList.append(word.lower())
+lower_list = []
+for word in input_listt:
+    lower_list.append(word.lower())
 ```
 
 Instead, you can use `map()` to push the loop into compiled C code:
 
 ```python
-lowerList = map(str.lower(), inputList)
+lower_list = map(str.lower, input_list)
 ```
 
 Also, in Python 2.0 or above, there are list comprehensions. List comprehension are the "pythonic" way to approach this situation. `map()` is more often used in JavaScript. We recommend usage of list comprehension:
 
 ```python
-lowerList = [word.lower() \
-         for word in inputList]
+lower_list = [word.lower() \
+  for word in input_list]
 ```
 
 They are both more efficient than simple `for` loop statement.
@@ -58,16 +58,17 @@ They are both more efficient than simple `for` loop statement.
 
 ## Practice
 
-Use map to modify a list of strings such that all its elements are uppercase letters:
+Use list comprehension to modify a list of characters such that all its elements become uppercase:
 
 ```python
 strings = ['a', 'e', 'i', 'o', 'u']
 
-upperCase = ???(str.???, strings)
+lower_list = [word.??? \
+  for word in ???]
 ```
 
-- map
 - upper()
+- strings
 - string
 - lower()
 - zip


### PR DESCRIPTION
Update variables to snake_case and update the PQ to use list comprehension as it is the recommended pythonic way

The output of :
```python
input_list = ['A', 'E', 'I', 'o', 'u']
lower_list = map(str.lower, input_list)
print(lower_list)
```
Looks like this:
```plain-text
<map object at 0x7f3d57a3f700>
```
Whereas the output of:
```python
input_list = ['A', 'E', 'I', 'o', 'u']

lower_list = [word.upper() \
  for word in input_list]
print(lower_list)
```
Looks like this:
```plain-text
['A', 'E', 'I', 'O', 'U']
```
So I changed the question to use list comprehension instead of map (we also recommend this)