### PR TITLE
remove type in the gap from Coding intro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Types of change:
 
 ### Fixed
 
+## September 6th 2021
+
+### Changed
+- [Coding intro- All Applicable Workouts - remove type in the gap from questions with multiple correct answers](https://github.com/enkidevs/curriculum/pull/2884)
 
 ## September 1st 2021
 

--- a/coding-intro/coding-intro-core/coding-intro-functions/robot-assemble-the-sandwich.md
+++ b/coding-intro/coding-intro-core/coding-intro-functions/robot-assemble-the-sandwich.md
@@ -5,12 +5,10 @@ category: must-know
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 

--- a/coding-intro/coding-intro-core/collections/accessing-dictionary-elements.md
+++ b/coding-intro/coding-intro-core/collections/accessing-dictionary-elements.md
@@ -10,7 +10,6 @@ practiceQuestion:
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 

--- a/coding-intro/coding-intro-core/collections/coding-intro-dictionaries.md
+++ b/coding-intro/coding-intro-core/collections/coding-intro-dictionaries.md
@@ -9,7 +9,6 @@ practiceQuestion:
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 

--- a/coding-intro/coding-intro-core/collections/coding-intro-dictionaries.md
+++ b/coding-intro/coding-intro-core/collections/coding-intro-dictionaries.md
@@ -5,7 +5,6 @@ category: must-know
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:

--- a/coding-intro/coding-intro-core/loops/ci-for-loops.md
+++ b/coding-intro/coding-intro-core/loops/ci-for-loops.md
@@ -5,7 +5,6 @@ category: must-know
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:

--- a/coding-intro/coding-intro-core/loops/while-do.md
+++ b/coding-intro/coding-intro-core/loops/while-do.md
@@ -8,7 +8,6 @@ aspects:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:


### PR DESCRIPTION
Remove type in the gap from questions that have multiple correct answers based on letter size, spacing, and others