### PR TITLE
Update populate-a-dictionary-exercise.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Types of change:
 
 ### Changed
 - [SQL - Add Trigger 2 - Remove outdated link](https://github.com/enkidevs/curriculum/pull/2891)
+- [Python - Populate A Dictionary Exercise - Replace the zip method with fromkeys](https://github.com/enkidevs/curriculum/pull/2892)
 
 ### Fixed
 - [Java - Using StringBuilder Class - Replace StringBuffer with StringBuilder](https://github.com/enkidevs/curriculum/pull/2887)

--- a/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
+++ b/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
@@ -10,13 +10,14 @@ category: coding
 
 setupCode:
   startingPoint: |
-    # 👋 Welcome to the Python coding playground. 
-    # Use these keys:
-    keys = ['ID', 'Age']
-    
-    # Populate this dictionary:
+    # 👋 Welcome to the Python coding playground.
+    # Create a dictionary
+    # Save the values in a different variable
+    # Save the keys in a different variable
+    # Clear the dictionary
+ 
+    # Use this dictionary:
     person = {}
-    
 
 ---
 
@@ -26,16 +27,15 @@ setupCode:
 
 ## Content
 
-> 👩‍💻 Your task is to populate a `dictionary` with a value of your choice and these keys:
-
-```python
-keys = ['ID', 'Age']
-```
-
-Don't forget to output the new `dictionary`.
+> 👩‍💻 Your task is to:
+> - **create a dictionary with at least one key-value pair**
+> - **save the values in a different variable**
+> - **save the keys in a different variable**
+> - **clear the dictionary**
 
 To solve this, try using the following concepts:
-- built-in method (`fromkeys`)
+- create a dictionary (`fromkeys`)
+- methods (`.values()`, `.keys()`, `.clear()`)
 
 Give it an honest try, and feel free to share your solution!
 

--- a/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
+++ b/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
@@ -27,7 +27,7 @@ setupCode:
 
 ## Content
 
-> 👩‍💻 Your task is to:
+> 👩‍💻 Using dictionary methods, your task is to:
 > - **create a dictionary with at least one key-value pair**
 > - **save the values in a different variable**
 > - **save the keys in a different variable**

--- a/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
+++ b/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
@@ -55,4 +55,8 @@ If you’re stuck, you can always read this footnote[1] or review the comments s
 
 [1: Hints]
 
-Add the `list` and a value to the `person` `dictionary` using the `fromkeys` method. 
+Create a new `dictionary` using `fromkeys` with at least one key-value pair.
+
+Use the built-in methods to extract the keys and values. 
+
+Clear the dictionary.

--- a/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
+++ b/python/python-core/populate-a-dictionary-exercise/populate-a-dictionary-exercise.md
@@ -11,10 +11,9 @@ category: coding
 setupCode:
   startingPoint: |
     # 👋 Welcome to the Python coding playground. 
-    # Use these two lists:
-    keys = ['Name', 'Surname', 'Profession']
-    values = ["Alan", "Turing", "Mathematician"]
-
+    # Use these keys:
+    keys = ['ID', 'Age']
+    
     # Populate this dictionary:
     person = {}
     
@@ -27,17 +26,16 @@ setupCode:
 
 ## Content
 
-> 👩‍💻 Your task is to populate a `dictionary` using these two `lists`:
+> 👩‍💻 Your task is to populate a `dictionary` with a value of your choice and these keys:
 
 ```python
-keys = ['Name', 'Surname', 'Profession']
-values = ["Alan", "Turing", "Mathematician"]
+keys = ['ID', 'Age']
 ```
 
 Don't forget to output the new `dictionary`.
 
 To solve this, try using the following concepts:
-- built-in method (`zip`)
+- built-in method (`fromkeys`)
 
 Give it an honest try, and feel free to share your solution!
 
@@ -57,4 +55,4 @@ If you’re stuck, you can always read this footnote[1] or review the comments s
 
 [1: Hints]
 
-Add the two `lists` to the `person` `dictionary` using the `zip` method. 
+Add the `list` and a value to the `person` `dictionary` using the `fromkeys` method. 


### PR DESCRIPTION
Replace the zip method with `fromkeys` in the `populate a dictionary` python exercise

Reason:
- The `zip` method isn't taught until the functional-programming course