### PR TITLE
Update the-import-statement.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Types of change:
 
 ### Fixed
 - [JavaScript - Symbol Special Properties - Fix the practice question by switching the answer order](https://github.com/enkidevs/curriculum/pull/2900)
+- [Python - Intro To Modules - Fix continuity between code examples](https://github.com/enkidevs/curriculum/pull/2902)
 
 ## September 20th 2021
 

--- a/python/python-core/intro-to-modules/the-import-statement.md
+++ b/python/python-core/intro-to-modules/the-import-statement.md
@@ -44,10 +44,10 @@ We will `import` and use a *method* exposed by the `my_adder` module[1] we defin
 import my_adder
 
 # now we can use methods exposed by it
-result = my_adder.add(3,4)
-print(result)
+my_adder.add(3,4)
 
-# This will be the output: 7
+# This will output:
+# The sum is: 7
 ```
 
 > 💡 A module needs to be imported only **once**, regardless of the number of times it is used as an argument for the `import` statement.


### PR DESCRIPTION
Fix continuity of examples in python/python-core/intro-to-modules

The first insight has a print defined in it, while the following insight has an additional print, making the example output incorrect