### PR TITLE
Update other-operations-on-files.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Types of change:
 - [JavaScript - Symbol Special Properties - Fix the practice question by switching the answer order](https://github.com/enkidevs/curriculum/pull/2900)
 - [Python - Intro To Modules - Fix continuity between code examples](https://github.com/enkidevs/curriculum/pull/2902)
 - [Javascript - The Difference Between Null Undefined And NaN - Remove function from pq as it wasn't taught yet](https://github.com/enkidevs/curriculum/pull/2899)
+- [Python - Other Operations On Files - Fix incorrect code output for file.read(7)](https://github.com/enkidevs/curriculum/pull/2903)
 
 ## September 20th 2021
 

--- a/python/python-core/basic-file-manipulation/how-to-open-a-file-object.md
+++ b/python/python-core/basic-file-manipulation/how-to-open-a-file-object.md
@@ -25,7 +25,7 @@ revisionQuestion:
 
 ## Content
 
-**Reading** from and **writing** to files in **Python 3** can easily be done using the `open()` function. This will create a `file` object, which can be used to call other support **methods** associated with it.
+**Reading** from and **writing** to files in **Python 3** can be done using the `open()` function. This will create a `file` object, which can be used to call other support **methods** associated with it.
 
 Consider the following syntax:
 

--- a/python/python-core/basic-file-manipulation/other-operations-on-files.md
+++ b/python/python-core/basic-file-manipulation/other-operations-on-files.md
@@ -56,7 +56,7 @@ print(file.read())
 file.close()
 
 # Output:
-# Input is:
+# Input is: This is
 # Current pos: 7
 # After seek: 0
 # This is my file

--- a/python/python-core/basic-file-manipulation/other-operations-on-files.md
+++ b/python/python-core/basic-file-manipulation/other-operations-on-files.md
@@ -39,7 +39,14 @@ In **Python**, the `tell()` function returns the current position in the **file*
 - `1`: which means at the current position;
 - `2`: which means at the end of the file.
 
-Let's see how `tell()` and `seek()` work in practice, considering a dummy `file.txt`[1]:
+Using this `file.txt`:
+
+```plain-text
+This is my file
+It has two lines of text
+```
+
+Let's see how `tell()` and `seek()` work in practice:
 
 ```python
 file = open('file.txt','r+')
@@ -111,17 +118,3 @@ Which method returns the current position of the file pointer within a **file ob
 - `seek()`
 - `open()`
 - `readline()`
-
----
-
-## Footnotes
-
-[1: File.txt Contents]
-
-```plain-text
-file = open('file.txt','r+')
-
-print(file.read())
-# This is my file
-# It has two lines of text
-```

--- a/python/python-core/basic-file-manipulation/other-operations-on-files.md
+++ b/python/python-core/basic-file-manipulation/other-operations-on-files.md
@@ -39,7 +39,7 @@ In **Python**, the `tell()` function returns the current position in the **file*
 - `1`: which means at the current position;
 - `2`: which means at the end of the file.
 
-Let's see how `tell()` and `seek()` work in practice, considering a dummy `file.txt`:
+Let's see how `tell()` and `seek()` work in practice, considering a dummy `file.txt`[1]:
 
 ```python
 file = open('file.txt','r+')
@@ -111,4 +111,17 @@ Which method returns the current position of the file pointer within a **file ob
 - `seek()`
 - `open()`
 - `readline()`
- 
+
+---
+
+## Footnotes
+
+[1: File.txt Contents]
+
+```plain-text
+file = open('file.txt','r+')
+
+print(file.read())
+# This is my file
+# It has two lines of text
+```

--- a/python/python-core/basic-file-manipulation/writing-files.md
+++ b/python/python-core/basic-file-manipulation/writing-files.md
@@ -36,7 +36,7 @@ path = '/usr/seba/new_file.txt'
 text = open(path, 'w+')
 ```
 
-Writing to the **file** can easily be done via the `write()` function. A single **string** may be passed as as **argument**, which will be written to the **file**. You can **split** the **string** into multiple lines by adding `\n` character where necessary.
+Writing to the **file** can be done via the `write()` function. A single **string** may be passed as as **argument**, which will be written to the **file**. You can **split** the **string** into multiple lines by adding `\n` character where necessary.
 
 ```python
 in = 'This is one line\n


### PR DESCRIPTION
Fix incorrect output shown in comment for `file.read(7)`
Our comment:
```plain-text
Input is: 
```
 has nothing as output for the print with "Input: " for the file:
```plain-text
This is my file
It has two lines of text
```
Whereas the correct output is:
```plain-text
Input is:  This is
```