### PR TITLE
Update reading-from-files.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ Types of change:
 ### Changed
 - [Go - If Statements - Improve the revision question](https://github.com/enkidevs/curriculum/pull/2904)
 
+### Fixed
+- [Python - Reading From Files - Fix incorrect info on readlines return type](https://github.com/enkidevs/curriculum/pull/2906)
+
 ## September 22nd 2021
 
 ### Added

--- a/python/python-core/basic-file-manipulation/reading-from-files.md
+++ b/python/python-core/basic-file-manipulation/reading-from-files.md
@@ -116,7 +116,7 @@ print(???.readline())
 
 ## Revision
 
-Suppose we want to read all lines from a file and return them as a string. Fill the gaps accordingly:
+Suppose we want to read all lines from a file and return them as a list. Fill the gaps accordingly:
 
 ```py
 file = open('test.txt', '???')


### PR DESCRIPTION
`readline()` returns a list or a binary object while `readlines()` returns a list

Fix the rq where it says `readlines()` returns a string