### PR TITLE
Update nested-functions.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ Types of change:
 ### Changed
 - [Go - If Statements - Improve the revision question](https://github.com/enkidevs/curriculum/pull/2904)
 
+### Fixed
+- [Python - Nested Functions - Fix incorrect output in content and pq](https://github.com/enkidevs/curriculum/pull/2907)
+
 ## September 22nd 2021
 
 ### Added

--- a/python/python-core/python-functions/nested-functions.md
+++ b/python/python-core/python-functions/nested-functions.md
@@ -45,7 +45,7 @@ When calling `out_func`, this is the output:
 
 ```python
 out_func(5)
-# (5, 6)
+# 5 6
 ```
 
 This shows that the outer function is called with the parameter, that parameter is then passed into the inner function with a value being returned to the outer function call.
@@ -69,10 +69,10 @@ outer(3)
 
 ???
 
-- `(3, 1)`
-- `(5, 3)`
-- `(3, 3)`
-- `(1, 3)`
+- `3 1`
+- `5 3`
+- `3 3`
+- `1 3`
 
 
 ---


### PR DESCRIPTION
Fix incorrect tuple output:
```plain-text
(5, 6)
```
Where the true output is:
![img](https://img.enkipro.com/2b86277ab47332ab9ad9592ad25da440.png)

This applies to the pq as well