### PR TITLE
Update types-boolean-and-number.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## September 27th 2021
+
+### Changed
+- [JavaScript - Strings, Numbers, And Booleans - Add semicolons to examplse to avoid confusion with new users](https://github.com/enkidevs/curriculum/pull/2909)
+
 ## September 24th 2021
 
 ### Fixed

--- a/javascript/javascript-core/types/types-boolean-and-number.md
+++ b/javascript/javascript-core/types/types-boolean-and-number.md
@@ -28,8 +28,8 @@ To store any sequence of characters, whether its one letter or multiple sentence
 A string is always wrapped in either `'single'` or `"double quotes"`
 
 ```javascript
-let company = "Enki"
-let google_search = 'How to learn JavaScript in one day'
+let company = "Enki";
+let google_search = 'How to learn JavaScript in one day';
 ```
 
 We can also perform operations on strings like the following:
@@ -81,8 +81,8 @@ On the first line declare a **boolean variable** named `a` that's `true`.
 On the second line declare a **number constant** named `b` with the value equal to `3.14`.
 
 ```javascript
-let ??? = ???
-??? ??? = ???
+let ??? = ???;
+??? ??? = ???;
 ```
 
 - `a`


### PR DESCRIPTION
add semicolons to strings numbers and booleans javascript practice question and string portion of the content

Reason: A user found it confusing that the insight mostly had semicolons while the question did not