### PR TITLE
Spelling mistake in interface

### DIFF
--- a/go/go-introduction/data-types-and-constants/go-data-types.md
+++ b/go/go-introduction/data-types-and-constants/go-data-types.md
@@ -98,7 +98,7 @@ The four data type groups in **Go** are:
 1. ???
 2. Aggregate
 3. Reference
-4. Interference
+4. Interface
 ```
 - Basic
 - Numbers


### PR DESCRIPTION
The options for the question about data types in Go should be:
1) Basic
2) Aggregrate
3) Reference
4) Interface ---- this is misspelled as **Interference**