### PR TITLE
Update airtable-linking-tables.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## November 23rd 2021
+
+### Fixed
+- [Airtable - Airtable Linking Tables - Fix incorrectly rendered answer for the PQ](https://github.com/enkidevs/curriculum/pull/2943)
+
 ## November 19th 2021
 
 ### Fixed

--- a/airtable/airtable-introduction/table-relationships/airtable-linking-tables.md
+++ b/airtable/airtable-introduction/table-relationships/airtable-linking-tables.md
@@ -44,7 +44,7 @@ Adding data to the linked fields is done by clicking on the `+` sign found in th
 
 To link two already existing tables you have to ???.
 
-- create a new field and select the 'Link <name of table to be linked>'
+- `create a new field and select the Link <name of table to be linked>`
 - create a new base and link it using base linking
 - delete the table and create a new table from scratch
 


### PR DESCRIPTION
fix incorrectly rendered answer field in airtable linking tables
Before:
![before](https://img.enkipro.com/b776d77d411bdaf222439750d579d89f.jpeg)

After:
![after](https://img.enkipro.com/5b3f0a742976ec5be9887e87bd7b8374.jpeg)