### PR TITLE
Update sharing-data-by-bundling.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## December 29th 2021
+
+### Fixed
+- [Git - Sharing Data By Bundling - Remove git keyword from cd command and make the PQ a single line command](https://github.com/enkidevs/curriculum/pull/2969)
+
 ## December 27th 2021
 
 ### Fixed

--- a/git/essentials/git-features-iv/sharing-data-by-bundling.md
+++ b/git/essentials/git-features-iv/sharing-data-by-bundling.md
@@ -39,7 +39,7 @@ To access the commits on another computer:
 
 ```bash
 git clone myBundle bundled_repo
-git cd bundled_repo
+cd bundled_repo
 ```
 
 To be safe, you can verify that the commit is valid before cloning:
@@ -56,8 +56,7 @@ git bundle verify ../myBundle
 How would you bundle the whole `newFeature` branch?
 
 ```bash
-git bundle ??? 
-   FeatureBranch ??? ???        
+git bundle ??? FeatureBranch ??? ???        
 ```
 
 - `create`


### PR DESCRIPTION
remove `git` keyword from the `cd folder` command. 

Move answers from PQ onto a single line as it is a single-line command that used to be rendered as 2 lines because of the spacing