### PR TITLE
remove type in the gap from RQ in nested lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## February 14th 2022
+
+### Changed
+-[Web - Nested Lists - Remove type in the gap as it has no value](https://github.com/enkidevs/curriculum/pull/3040)
+
 ## February 7th 2022
 
 ### Fixed

--- a/web/html/lists/nested-lists.md
+++ b/web/html/lists/nested-lists.md
@@ -19,7 +19,6 @@ practiceQuestion:
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 


### PR DESCRIPTION
Remove type in the gap as there is no benefit in typing out the 1 or 2 compared to selecting them