### PR TITLE
Update what-are-formulas.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,11 @@ Types of change:
 
 ### Fixed
 
+## February 15th 2022
+
+### Fixed
+- [Spreadsheets - What Are Formulas - fix markdown table not rendering correctly in PQ](https://github.com/enkidevs/curriculum/pull/3043)
+
 ## February 7th 2022
 
 ### Fixed

--- a/spreadsheets/spreadsheets-introduction/intro-to-functions-and-formulas/what-are-formulas.md
+++ b/spreadsheets/spreadsheets-introduction/intro-to-functions-and-formulas/what-are-formulas.md
@@ -42,7 +42,8 @@ Now, every time you update the data in one of the cells found in the formula (`B
 ## Practice
 
 Consider the following spreadsheet:
-| ‏‏‎ ‎ | A    | B        |
+
+| &#160; | A    | B        |
 |---|------|----------|
 | 1 | Week | Spending |
 | 2 | 1    | 23       |


### PR DESCRIPTION
add spacing between the table and sentence above it

Current live:
![live](https://img.enkipro.com/d452cdc66d4f9bbd234db003e4af8d99.jpeg)

With line spacing between sentence and table fixed (missing the non breaking space):
![fixed-spacing](https://img.enkipro.com/f1f049b686ce917766db8bef931629a3.jpeg)

Nbps added but spacing not fixed 
![add-nbsp-dont-fix-spacing](https://img.enkipro.com/3b310b6fc39542e3c11662576eef7495.jpeg)

Fixed (added nbps and spacing between sentence and table)
![fixed](https://img.enkipro.com/74b26c8efba258220fee3bff394481c3.jpeg)