### PR TITLE
Update intro-cite.md

### DIFF
--- a/web/html/citation-elements/intro-cite.md
+++ b/web/html/citation-elements/intro-cite.md
@@ -98,12 +98,12 @@ What HTML element is best to use in this example?
 tag = ???
 ```
 
-- `<cite>`
-- `<quote>`
-- `<blockquote>`
-- `<q>`
-- `<movie>`
-- `<title>`
+- `cite`
+- `quote`
+- `blockquote`
+- `q`
+- `movie`
+- `title`
 
 
 ---


### PR DESCRIPTION
Remove `<` `>` from answers as the code block already has <tag> in it making the current correct answer:
<<cite>> instead of <cite>