### PR TITLE
Update python-data-types.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ Types of change:
 
 ### Fixed
 
+## November 17th 2022
+
+### Changed
+- [Python - Python Data Types - Remove type in the gap and reorder question so different correct answers cannot be evaluated as a wrong answer](https://github.com/enkidevs/curriculum/pull/3132)
 
 ## November 7th 2022
 

--- a/python/python-core/syntax-and-numerical-operators/python-data-types.md
+++ b/python/python-core/syntax-and-numerical-operators/python-data-types.md
@@ -10,7 +10,6 @@ links:
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:
@@ -74,17 +73,23 @@ Other Python data types that you'll soon learn about are:
 
 ## Practice
 
-What class does the following return?
+Match the value to its type.
 
 ```python
->>> type('Learning Python')
-# <class '???'>
+type(???)
+# <class 'float'>
+
+type(???)
+# <class 'str'>
+
+type(???)
+# <class 'int'>
 ```
 
-- str
-- string
-- text
-- data
+- 15.0
+- 'Hello World'
+- 17
+- True
 
 ---
 


### PR DESCRIPTION
Asking people to type `str` instead of `string` to get the correct answer might not have much value when learning.

Doing the opposite might have more value, so I removed `type-in-the-gap`, leaving only one correct answer and added 2 additional types to be answered with also 1 possible answer.