### PR TITLE
Update example to show decreasing capacity

### DIFF
--- a/go/go-introduction/pointers-structs-arrays-slices/slices-ii.md
+++ b/go/go-introduction/pointers-structs-arrays-slices/slices-ii.md
@@ -62,14 +62,13 @@ fmt.Println("length=", len(num))
 fmt.Println("capacity=", cap(num))
 // capacity= 6 
 
-num = num[:5]
+num = num[3:]
 fmt.Println(num)
-// [2 4 8 16 32]
+// [16 32 64]
 fmt.Println("length=", len(num))
-// length= 5
+// length= 3
 fmt.Println("capacity=", cap(num))
-// capacity= 6
-
+// capacity= 3
 ```
 
 


### PR DESCRIPTION
On line 38, it says that you can decrease the length and capacity of a slice. In the examples, however, it shows two examples of decreasing the length and none of decreasing the capacity. I made a change to show both.