### PR TITLE
Remove type in the gap

### DIFF
--- a/python/python-core/bits-bytes-hexadecimals/get-the-most-of-float-s.md
+++ b/python/python-core/bits-bytes-hexadecimals/get-the-most-of-float-s.md
@@ -9,12 +9,10 @@ notes: abc
 practiceQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 revisionQuestion:
   formats:
     - fill-in-the-gap
-    - type-in-the-gap
   context: standalone
 ---
 


### PR DESCRIPTION
Requiring users to type out X amount of 0's doesn't help with learning, so i've removed type in the gap